### PR TITLE
Dampen contcorr writes by entry magnitude

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -117,10 +117,15 @@ void update_correction_history(const Position& pos,
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 129 / 128) * mask;
-    const int    bonus4 = (bonus * 61 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    constexpr int D = CORRECTION_HISTORY_LIMIT;
+    constexpr std::pair<int, int> contcorrWeights[] = {{-2, 129}, {-4, 61}};
+    for (auto [ofs, mult] : contcorrWeights)
+    {
+        auto& e = (*(ss + ofs)->continuationCorrectionHistory)[pc][to];
+        int   v = int(e);
+        int   b = std::clamp((bonus * mult / 128) * mask * (1536 - std::abs(v)) / 2048, -D, D);
+        e       = std::int16_t(v + b - v * std::abs(b) / D);
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
## Summary

- Scale contcorr write bonuses by (1536 - |entry|) / 2048
- Fresh entries get 25% baseline dampening, saturated entries up to 75%
- Loop over {ss-2, ss-4} weights with inline gravity formula, single read-write per entry
- No header changes

## Predicted behavior

- STC (mean |entry| = 84): 29% dampening, noise reduction on initial writes
- LTC (mean |entry| = 364): 43% dampening, established entry protection

Bench: 2580426