### PR TITLE
Retune correction_value weights post-CMHC

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -89,7 +89,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
+    return 11433 * pcv + 7345 * micv + 12749 * (wnpcv + bnpcv) + 9500 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation


### PR DESCRIPTION
## Summary

- Increase contcorr (cntcv) weight from 8022 to 9500 in correction_value()
- Decrease minor piece correction (micv) weight from 8823 to 7345
- CMHC (commit 8b6d8def) makes contcorr entries more reliable by scaling writes based on continuation history sign agreement, justifying higher read weight
- Total weight budget preserved (redistribution, not amplification)

## Bench

2244896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized evaluation parameters for enhanced position assessment accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->