### PR TITLE
Remove minor piece correction from eval correction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,7 +81,6 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos).at(us).pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
     const int   cntcv =
@@ -89,7 +88,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
+    return (11433 + 8823) * pcv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -109,7 +108,6 @@ void update_correction_history(const Position& pos,
     auto&         shared        = workerThread.sharedHistory;
 
     shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 155 / 128;
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 


### PR DESCRIPTION
## Summary

- Remove minorPieceCorrHist from correction_value() read and update_correction_history() write paths
- Redistribute weight to pawnCorrHist: pcv weight becomes 11433+8823 = 20256
- Saves one hash table lookup per node (approximately 10-30 cycles from L2/L3 access)
- Instrumentation data showed minor correction contributes 21.5% at STC but drops to 15.6% at LTC, suggesting pawn and nonpawn tables absorb its signal at depth
- Simplification: uses SPRT (-1.75, 0.25) bounds on Fishtest

## Bench

2498643