### PR TITLE
Weight contcorr reads asymmetrically: ss-2 at 5/4, ss-4 at 3/4

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,9 +85,11 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
     const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+      m.is_ok()
+          ? (5 * (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+           + 3 * (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()])
+            / 4
+          : 8;
 
     return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
 }


### PR DESCRIPTION
## Summary

- Weight ss-2 and ss-4 contcorr entries asymmetrically in correction_value()
- ss-2 gets 5/4 weight, ss-4 gets 3/4 weight (total preserved at 2.0x vs original 1+1)
- ss-4 is less reliable (4 plies back, more decay)
- Asymmetric weighting amplifies the stronger signal (ss-2) and dampens the weaker (ss-4)
- Benefits more at LTC where entries are larger (mean 364), since magnitude difference grows

## Bench

2244499