### PR TITLE
Share contcorr with sublinear D scaling

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -226,6 +226,9 @@ struct SharedHistories {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        // Sublinear D scaling: D = 1024 * (1 + (threadCount - 1) / 3)
+        contcorrDEff = int(std::min(size_t(CORRECTION_HISTORY_LIMIT) * (1 + (threadCount - 1) / 3),
+                                    size_t(std::numeric_limits<std::int16_t>::max())));
     }
 
     size_t get_size() const { return sizeMinus1 + 1; }
@@ -263,9 +266,46 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    static constexpr int DefaultContCorrFill = 7;
+
+    using AtomicPieceToCorrHist =
+      AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
+    MultiArray<AtomicPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        constexpr size_t total = PIECE_NB * SQUARE_NB;
+        size_t           start = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(DefaultContCorrFill);
+    }
+
+    template<typename E>
+    struct ScaledEntry {
+        E&   e;
+        int  d;
+        void operator<<(int bonus) {
+            int cb = std::clamp(bonus, -d, d);
+            int v  = int(e);
+            e      = v + cb - v * std::abs(cb) / d;
+        }
+    };
+
+    template<typename E>
+    ScaledEntry<E> scaled(E& entry) {
+        return {entry, contcorrDEff};
+    }
+
+    void update_contcorr(AtomicPieceToCorrHist& hist, Piece pc, Square to, int bonus) {
+        auto se = scaled(hist[pc][to]);
+        se << bonus;
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;
+    int    contcorrDEff;
 };
 
 }  // namespace Stockfish

--- a/src/history.h
+++ b/src/history.h
@@ -226,8 +226,8 @@ struct SharedHistories {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
-        // Sublinear D scaling: D = 1024 * (1 + (threadCount - 1) / 3)
-        contcorrDEff = int(std::min(size_t(CORRECTION_HISTORY_LIMIT) * (1 + (threadCount - 1) / 3),
+        // Sublinear D scaling: D = 1024 * (threadCount + 2) / 3
+        contcorrDEff = int(std::min(size_t(CORRECTION_HISTORY_LIMIT) * (threadCount + 2) / 3,
                                     size_t(std::numeric_limits<std::int16_t>::max())));
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -119,8 +119,8 @@ void update_correction_history(const Position& pos,
     const Piece  pc     = pos.piece_on(to);
     const int    bonus2 = (bonus * 129 / 128) * mask;
     const int    bonus4 = (bonus * 61 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    shared.update_contcorr(*(ss - 2)->continuationCorrectionHistory, pc, to, bonus2);
+    shared.update_contcorr(*(ss - 4)->continuationCorrectionHistory, pc, to, bonus4);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -281,8 +281,9 @@ void Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->continuationCorrectionHistory =
+          &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->staticEval = VALUE_NONE;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
@@ -563,7 +564,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -571,7 +572,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -593,9 +594,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(7);
+    sharedHistory.clear_contcorr_range(numaThreadIdx, numaTotal);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -62,20 +62,20 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                                   pv;
+    PieceToHistory*                         continuationHistory;
+    SharedHistories::AtomicPieceToCorrHist* continuationCorrectionHistory;
+    int                                     ply;
+    Move                                    currentMove;
+    Move                                    excludedMove;
+    Value                                   staticEval;
+    int                                     statScore;
+    int                                     moveCount;
+    bool                                    inCheck;
+    bool                                    ttPv;
+    bool                                    ttHit;
+    int                                     cutoffCnt;
+    int                                     reduction;
 };
 
 
@@ -290,9 +290,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
## Summary

- Share continuation correction history across threads with sublinear D scaling
- D_effective = 1024 * (1 + (threadCount - 1) / 3)
- At 1 thread: D=1024 (bench identical to master: 2288704)
- At 8 threads: D=3413 (vs halfshift 4096 which failed LTC SMP, vs full 8192)
- Uses atomic entries and ScaledEntry proxy with idivl for runtime D
- Created because tscale-halfshift failed LTC SMP on Fishtest

## Bench

2288704