### PR TITLE
int8 continuation correction history compression (D=64, SCALE=16)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -149,6 +149,15 @@ using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 // PieceToHistory instead of ButterflyBoards.
 using ContinuationHistory = MultiArray<PieceToHistory, PIECE_NB, SQUARE_NB>;
 
+// int8 D=64 continuation correction with WDIV=16, RMUL=16.
+constexpr int CONTCORR_D                 = 64;
+constexpr int CONTCORR_SCALE             = 16;
+constexpr int CONTCORR_FILL              = 0;
+constexpr int CONTCORR_FALLBACK          = 8;
+constexpr int CONTCORR_WEIGHT_MULTIPLIER = 1;
+using CompactContCorrHist                = Stats<std::int8_t, CONTCORR_D, PIECE_NB, SQUARE_NB>;
+
+
 // PawnHistory is addressed by the pawn structure and a move's [piece][to]
 using PawnHistory =
   DynStats<AtomicStats<std::int16_t, 8192, PIECE_NB, SQUARE_NB>, PAWN_HISTORY_BASE_SIZE>;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,11 +85,15 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
     const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+      m.is_ok()
+          ? int((*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()])
+              * CONTCORR_SCALE
+            + int((*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()])
+                * CONTCORR_SCALE
+          : CONTCORR_FALLBACK;
 
-    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
+    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv)
+         + 8022 * CONTCORR_WEIGHT_MULTIPLIER * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -117,8 +121,8 @@ void update_correction_history(const Position& pos,
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 129 / 128) * mask;
-    const int    bonus4 = (bonus * 61 / 128) * mask;
+    const int    bonus2 = (bonus * 129 / 128) * mask / CONTCORR_SCALE;
+    const int    bonus4 = (bonus * 61 / 128) * mask / CONTCORR_SCALE;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
@@ -595,7 +599,7 @@ void Search::Worker::clear() {
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
-            h.fill(7);
+            h.fill(CONTCORR_FILL);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -62,20 +62,20 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                pv;
+    PieceToHistory*      continuationHistory;
+    CompactContCorrHist* continuationCorrectionHistory;
+    int                  ply;
+    Move                 currentMove;
+    Move                 excludedMove;
+    Value                staticEval;
+    int                  statScore;
+    int                  moveCount;
+    bool                 inCheck;
+    bool                 ttPv;
+    bool                 ttHit;
+    int                  cutoffCnt;
+    int                  reduction;
 };
 
 
@@ -290,9 +290,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory                                captureHistory;
+    ContinuationHistory                                  continuationHistory[2][2];
+    MultiArray<CompactContCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
## Summary

- Compress continuation correction history from int16 (D=1024) to int8 (D=64)
- Write divisor SCALE=16: bonus is divided by 16 before writing to int8 entries
- Read multiplier SCALE=16: int8 values are multiplied by 16 when read in correction_value()
- Table size per worker drops from 2MB to 1MB (PIECE_NB * SQUARE_NB * PIECE_NB * SQUARE_NB)
- At cutechess concurrency=32, total contcorr memory drops from 64MB to 32MB, reducing L3 pressure from 67% to 33% on a 96MB cache

## Cache impact by architecture

| Architecture | L3 size | 32 workers int16 | 32 workers int8 | Savings |
|-------------|---------|-----------------|----------------|---------|
| Ryzen 7950X3D (hw2) | 96MB | 67% | 33% | 34% of L3 |
| Arrow Lake (hw1) | 36MB | 178% (spills) | 89% | No spill |
| Fishtest laptops | 12-24MB | 267-533% | 133-267% | Significant |

## Cutechess results (preliminary)

711 games on hw2 STC: +7.82 Elo (wide CI, needs more games to confirm)

## Files modified

- src/history.h (CompactContCorrHist type, constants)
- src/search.h (Stack pointer type, worker member type)
- src/search.cpp (read with SCALE multiply, write with SCALE divide, fill with CONTCORR_FILL)

## Bench

Differs from master (int8 compression changes search behavior)