### PR TITLE
Skip correction history updates at shallow depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1472,7 +1472,7 @@ moves_loop:  // When in check, search starts here
 
     // Adjust correction history if the best move is not a capture
     // and the error direction matches whether we are above/below bounds.
-    if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
+    if (depth >= 3 && !ss->inCheck && !(bestMove && pos.capture(bestMove))
         && (bestValue > ss->staticEval) == bool(bestMove))
     {
         auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / (bestMove ? 10 : 8),


### PR DESCRIPTION
## Summary

- Skip update_correction_history when depth < 3
- At shallow depths (d=1-2), bonus formula produces small noisy values
- Reduces pollution of correction tables without losing deep search signal

## Technical Details

The bonus is `(bestValue - staticEval) * depth / 10`. At depth=1, max bonus is ~102 out of 1024 limit. These shallow positions have not been searched deeply enough for bestValue to reliably reflect eval error.

## Bench

2855561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal move evaluation logic by adding additional conditions for bonus application during position analysis. This may affect engine evaluation behavior and move selection in certain game states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->