### PR TITLE
Add material-key correction history entry

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -171,12 +171,14 @@ struct CorrectionBundle {
     StatsEntry<T, D, true> minor;
     StatsEntry<T, D, true> nonPawnWhite;
     StatsEntry<T, D, true> nonPawnBlack;
+    StatsEntry<T, D, true> material;
 
     void operator=(T val) {
         pawn         = val;
         minor        = val;
         nonPawnWhite = val;
         nonPawnBlack = val;
+        material     = val;
     }
 };
 
@@ -258,6 +260,13 @@ struct SharedHistories {
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+
+    auto& material_correction_entry(const Position& pos) {
+        return correctionHistory[pos.material_key() & sizeMinus1];
+    }
+    const auto& material_correction_entry(const Position& pos) const {
+        return correctionHistory[pos.material_key() & sizeMinus1];
     }
 
     UnifiedCorrectionHistory correctionHistory;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -916,6 +916,7 @@ void Position::do_move(Move                      m,
         prefetch(&history->minor_piece_correction_entry(*this));
         prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
         prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
+        prefetch(&history->material_correction_entry(*this));
     }
 
     // Set capture piece

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,12 +84,13 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
+    const int   matcv  = shared.material_correction_entry(pos).at(us).material;
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 8022 * cntcv;
+    return 11433 * pcv + 8823 * micv + 12749 * (wnpcv + bnpcv) + 7000 * matcv + 8022 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -112,6 +113,7 @@ void update_correction_history(const Position& pos,
     shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 155 / 128;
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.material_correction_entry(pos).at(us).material << bonus * 140 / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());


### PR DESCRIPTION
## Summary

- Add material_key-indexed correction history to track eval errors by material config
- material_key() already maintained incrementally (zero overhead to access)
- Read weight 7000 (below minor 8823), write weight 140/128
- Prefetch added in do_move alongside existing correction prefetches

## Technical Details

Existing correction entries use pawn_key, minor_piece_key, non_pawn_key. None captures total material balance independently of piece placement. Material imbalances (R+B vs R+N, Q vs 2R) create systematic eval biases. A dedicated entry learns these biases.

Changes:
- history.h: add `material` field to CorrectionBundle, `material_correction_entry()` accessor
- search.cpp: read matcv in correction_value(), write in update_correction_history()
- position.cpp: prefetch material_correction_entry in do_move()

## Bench

2240106