### PR TITLE
Skip correction history updates at depth < 5

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1472,7 +1472,7 @@ moves_loop:  // When in check, search starts here
 
     // Adjust correction history if the best move is not a capture
     // and the error direction matches whether we are above/below bounds.
-    if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
+    if (depth >= 5 && !ss->inCheck && !(bestMove && pos.capture(bestMove))
         && (bestValue > ss->staticEval) == bool(bestMove))
     {
         auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / (bestMove ? 10 : 8),


### PR DESCRIPTION
## Summary

- Skip update_correction_history when depth < 5
- More aggressive variant of contcorr-depthgate (depth < 3)
- At depths 1-4, bonus formula produces values too small to meaningfully update correction tables

## Technical Details

The bonus is `(bestValue - staticEval) * depth / 10`. At depth 4, max bonus is ~409 (40% of 1024 limit). Shallow positions have not been searched deeply enough for bestValue to reliably reflect eval error. By requiring depth >= 5, only positions with substantial search backing update the tables.

## Bench

2563288