### PR TITLE
Share contcorr with thread-scaled D via shift

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -215,6 +215,9 @@ using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 
+// Atomic PieceTo correction history for shared continuation correction
+using AtomicPieceToCorrHist = AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads
 // on a given NUMA node. The passed size must be a power of two to make
@@ -226,6 +229,15 @@ struct SharedHistories {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+
+        // Compute log2(threadCount * 1024) for shift-based division
+        int tc       = int(threadCount);
+        contcorrDShift = 10;
+        while (tc > 1)
+        {
+            tc >>= 1;
+            contcorrDShift++;
+        }
     }
 
     size_t get_size() const { return sizeMinus1 + 1; }
@@ -260,12 +272,24 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
+    // Update shared contcorr entry with thread-scaled D via shift
+    void update_contcorr(AtomicPieceToCorrHist& hist, Piece pc, Square to, int bonus) {
+        auto& e       = hist[pc][to];
+        int   d       = 1 << contcorrDShift;
+        int   cb      = std::clamp(bonus, -d, d);
+        int   v       = int(e);
+        int   gravity = v * std::abs(cb);
+        int   mask    = (gravity >> 31) & (d - 1);
+        e             = v + cb - ((gravity + mask) >> contcorrDShift);
+    }
+
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
-
+    MultiArray<AtomicPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;
+    int    contcorrDShift;
 };
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -119,8 +119,8 @@ void update_correction_history(const Position& pos,
     const Piece  pc     = pos.piece_on(to);
     const int    bonus2 = (bonus * 129 / 128) * mask;
     const int    bonus4 = (bonus * 61 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    shared.update_contcorr(*(ss - 2)->continuationCorrectionHistory, pc, to, bonus2);
+    shared.update_contcorr(*(ss - 4)->continuationCorrectionHistory, pc, to, bonus4);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -281,7 +281,7 @@ void Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
         (ss - i)->staticEval                    = VALUE_NONE;
     }
 
@@ -563,7 +563,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -571,7 +571,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -593,9 +593,20 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(7);
+    // Clear shared continuation correction history (distributed across threads)
+    {
+        size_t totalEntries = PIECE_NB * SQUARE_NB;
+        size_t start        = uint64_t(numaThreadIdx) * totalEntries / numaTotal;
+        size_t end          = numaThreadIdx + 1 == numaTotal
+                                ? totalEntries
+                                : uint64_t(numaThreadIdx + 1) * totalEntries / numaTotal;
+        for (size_t i = start; i < end; i++)
+        {
+            Piece  pc = Piece(i / SQUARE_NB);
+            Square sq = Square(i % SQUARE_NB);
+            sharedHistory.continuationCorrectionHistory[pc][sq].fill(7);
+        }
+    }
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -64,7 +64,7 @@ namespace Search {
 struct Stack {
     Move*                       pv;
     PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
+    AtomicPieceToCorrHist* continuationCorrectionHistory;
     int                         ply;
     Move                        currentMove;
     Move                        excludedMove;
@@ -290,9 +290,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
## Summary

Share continuation correction history across threads with thread-scaled
gravity D = 1024 * threadCount. Division by D uses arithmetic right shift
with corrected rounding (toward zero, matching C++ / semantics), avoiding
idivl instruction entirely.

Key properties:
- At 1 thread: D=1024, shift=10, bench matches master (2288704)
- At 8 threads: D=8192, shift=13, slower gravity compensates for SMP write amplification
- No idivl (saves 28-72 cycles/node on older Fishtest workers like Haswell/Skylake)
- No conditional branch in the update path
- Correct rounding via (gravity + ((gravity >> 31) & (d-1))) >> shift
- All entries are atomic (memory_order_relaxed) per maintainer requirements

Bench: 2288704