### PR TITLE
Skip conthist writes with delta < 100 (filter ~50%)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int cb          = std::clamp(scaledBonus, -30000, 30000);
+            int val         = int(historyEntry);
+            int newVal      = val + cb - val * std::abs(cb) / 30000;
+            if (std::abs(newVal - val) >= 100)
+                historyEntry = newVal;
         }
     }
 }


### PR DESCRIPTION
Per-worker ContinuationHistory write threshold. Skip writes where the actual entry change (delta) is less than 100 out of D=30000 range (0.33%). Filters ~50% of writes based on delta instrumentation. Reduces cache pollution from noise writes. Bench: 2400858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal algorithm for history management with enhanced bounds checking and non-linear adjustment calculations to ensure more stable data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->