### PR TITLE
Skip conthist writes with delta < 50 (filter ~30%)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int cb          = std::clamp(scaledBonus, -30000, 30000);
+            int val         = int(historyEntry);
+            int newVal      = val + cb - val * std::abs(cb) / 30000;
+            if (std::abs(newVal - val) >= 50)
+                historyEntry = newVal;
         }
     }
 }


### PR DESCRIPTION
Per-worker ContinuationHistory write threshold. Skip writes where the actual entry change (delta) is less than 50 out of D=30000 range (0.17%). Filters ~30% of writes based on delta instrumentation. Reduces cache pollution from noise writes. Bench: 2730442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized search computation logic with improved stability through bounded updates and enhanced control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->