### PR TITLE
Skip destructive ContinuationHistory writes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,12 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int val         = int(historyEntry);
+            bool destructive = (val > -541 && scaledBonus < 0) || (val < -541 && scaledBonus > 0);
+            if (!destructive)
+                historyEntry << scaledBonus;
         }
     }
 }


### PR DESCRIPTION
Skip writes to ContinuationHistory when the scaled bonus opposes the existing entry sign. Instrumentation shows 35% of writes are destructive (opposite sign to established entry). These writes add noise and degrade entry quality. Filtering them preserves the accumulated signal. Bench: 2597221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved history tracking robustness by preventing certain data overwrites that could invert or corrupt previously accumulated values, resulting in more reliable algorithm behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->