### PR TITLE
Skip small destructive ContinuationHistory writes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,12 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int val         = int(historyEntry);
+            bool destructive = (val > -541 && scaledBonus < 0) || (val < -541 && scaledBonus > 0);
+            if (!(destructive && std::abs(scaledBonus) < 100))
+                historyEntry << scaledBonus;
         }
     }
 }


### PR DESCRIPTION
Skip ContinuationHistory writes that are both destructive (opposing entry sign) and small (|scaledBonus| < 100). Large destructive writes are preserved as they represent genuine move reevaluation. Filters ~14% of total writes (noise portion of 35% destructive). Bench: 2438737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened the search mechanism with additional validation checks to ensure data integrity and prevent unintended updates during result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->