### PR TITLE
Skip destructive writes to established ContinuationHistory entries

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,14 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int val         = int(historyEntry);
+            int adjusted    = val + 541;
+            bool established = std::abs(adjusted) > 2000;
+            bool opposing    = (adjusted > 0 && scaledBonus < 0) || (adjusted < 0 && scaledBonus > 0);
+            if (!(established && opposing))
+                historyEntry << scaledBonus;
         }
     }
 }


### PR DESCRIPTION
Skip ContinuationHistory writes that oppose the established direction of well-populated entries (moved 2000+ units from fill value -541). Fresh and weakly-established entries remain freely writable. Fixes the ratcheting bug in v1 where entries could only move in one direction. Bench: 3108599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined history entry update mechanism with additional validation checks. History entries now conditionally update based on multiple factors, preventing certain updates when existing data conflicts with incoming calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->