### PR TITLE
Skip zero-delta writes in atomic history updates

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -78,7 +78,9 @@ struct StatsEntry {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        T   newval       = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if (newval != val)
+            *this = newval;
 
         assert(std::abs(T(*this)) <= D);
     }


### PR DESCRIPTION
Skip writes in atomic StatsEntry operator<< when the gravity formula produces the same value as the current entry. At LTC, 32% of shared correction table writes produce zero delta (entry at saturation). Each skipped write avoids cache-line invalidations across all threads. Non-atomic (per-worker) path is unchanged. Bench: 2288704 (matches master at 1T).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized statistics update operations by eliminating unnecessary atomic writes when computed values remain unchanged, reducing write overhead and improving performance without affecting final results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->