### PR TITLE
Skip small-delta writes in atomic history updates (threshold 4)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -78,7 +78,9 @@ struct StatsEntry {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        T   newval       = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if (std::abs(newval - val) >= 4)
+            *this = newval;
 
         assert(std::abs(T(*this)) <= D);
     }


### PR DESCRIPTION
Skip writes in atomic StatsEntry operator<< when the gravity formula changes the entry by less than 4 units. At LTC, 48% of shared correction table writes produce delta < 4 (0.4% of D=1024 range). Reduces cache coherence traffic by filtering noise writes. Non-atomic path unchanged. Bench: 2169189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized history update computation. Atomic histories may now skip updates below a threshold value, while non-atomic histories continue processing all updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->