### PR TITLE
Skip ContinuationHistory writes with delta < 200

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1889,8 +1889,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             if (historyEntry > 0)
                 positiveCount++;
 
-            int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int multiplier  = CMHCMultipliers[positiveCount];
+            int scaledBonus = (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            int cb          = std::clamp(scaledBonus, -30000, 30000);
+            int val         = int(historyEntry);
+            int newVal      = val + cb - val * std::abs(cb) / 30000;
+            if (std::abs(newVal - val) >= 200)
+                historyEntry = newVal;
         }
     }
 }


### PR DESCRIPTION
Skip writes in update_continuation_histories when the gravity formula changes the entry by less than 200 out of D=30000 (0.67%). Filters 56% of writes based on instrumentation at both d13 and d22 (self-similar). Bench: 2239355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized search ranking mechanism with enhanced stability through improved filtering thresholds and bounds-checking. These changes reduce extreme fluctuations and ensure more consistent search result relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->