### PR TITLE
Simplify conthist base bonus to uniform constant

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1890,7 +1890,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            historyEntry << (bonus * weight * multiplier / 131072) + 16;
         }
     }
 }


### PR DESCRIPTION
Replace ply-conditional base bonus (82 for ply 1 only, 0 for plies 2-6) with uniform +16 for all plies. Per-ply instrumentation shows ply 1 is 19% of writes; 82*0.19=16 preserves the average contribution across all plies while removing the conditional multiplication. Bench: 2420944