### PR TITLE
Remove ply-1 base bonus from continuation history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1890,7 +1890,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 82 * (i < 2);
+            historyEntry << (bonus * weight * multiplier / 131072);
         }
     }
 }


### PR DESCRIPTION
Remove the +82 * (i < 2) base bonus from update_continuation_histories. This constant positive bias is applied only at ply 1 (19% of writes). Instrumentation shows ply 1 already has the strongest signal (weight=1106, mean delta=565) and does not need an artificial boost. Simplification: removes one multiplication, one comparison, and one addition per ply. Bench: 2389047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected continuation history calculations by removing an erroneous bias that was applied to the first two entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->