### PR TITLE
Skip history writes with delta of zero or one

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -78,7 +78,9 @@ struct StatsEntry {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        T   newval       = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if (std::abs(newval - val) > 1)
+            *this = newval;
 
         assert(std::abs(T(*this)) <= D);
     }


### PR DESCRIPTION
Skip writes in StatsEntry operator<< when the gravity formula changes the entry by 0 or 1. At LTC, 38-43% of shared correction table writes have delta <= 1 (out of D=1024). For per-worker ContinuationHistory (D=30000), ~15% have delta <= 1. Reduces cache write traffic with minimal information loss. Bench: 2904421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized stat value updates to apply only when changes exceed a minimum threshold, reducing unnecessary recalculations and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->