### PR TITLE
Skip zero-delta writes on shared atomic tables

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -78,7 +78,13 @@ struct StatsEntry {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        T   newval       = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if constexpr (Atomic)
+        {
+            if (newval == val)
+                return;
+        }
+        *this = newval;
 
         assert(std::abs(T(*this)) <= D);
     }


### PR DESCRIPTION
## Summary
Skip zero-delta writes on shared atomic tables. When operator<< computes
a new value identical to the current value, skip the store. Applies only
to Atomic=true tables via if constexpr. Per-worker tables unaffected.

## Rationale
x86-64 has no hardware silent store elimination. Every atomic store triggers
a Read-For-Ownership (RFO) even when the value does not change.

Instrumentation at 8T d24 shows 55-60% of shared correction writes are zero-delta:
- pawnCorr: 60.0%, minorCorr: 54.7%, nonpawnW: 58.2%
- nonpawnB: 57.5%, contCorr2: 57.5%, contCorr4: 58.5%

Total: ~82B writes, ~48B zero-delta = ~48B unnecessary RFOs skipped.

## Changes
- history.h: 2 lines added in operator<<. if constexpr (Atomic) { if (newval == val) return; }

## Properties
- Bench: 2288704 (matches master)
- Zero information loss
- No template parameter changes, no typedef changes

## Fishtest
LTC SMP (20+0.2, 8T) RUNNING: https://tests.stockfishchess.org/tests/view/69b7c5a81860ed703cccef16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal state tracking to reduce unnecessary operations, improving overall performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->