### PR TITLE
Scale correction history to full int16 range (K=31, D=31744)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -38,7 +38,7 @@ namespace Stockfish {
 constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
 constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
-constexpr int CORRECTION_HISTORY_LIMIT = 1024;
+constexpr int CORRECTION_HISTORY_LIMIT = 1024 * 31;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -87,9 +87,9 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+                  : 8 * 31;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return (12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv) / 31;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -105,20 +105,24 @@ void update_correction_history(const Position& pos,
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
-    constexpr int nonPawnWeight = 187;
-    auto&         shared        = workerThread.sharedHistory;
+    auto& shared = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    // Scale writes by K=31 (D=1024*31); correction_value() divides the weighted sum by 31.
+    // Entries are 31x larger; output and convergence rate are preserved.
+    const int pwnBonus = bonus * 31;
+    const int minBonus = bonus * 31 * 153 / 128;
+    const int npwBonus = bonus * 31 * 187 / 128;
+    shared.pawn_correction_entry(pos).at(us).pawn << pwnBonus;
+    shared.minor_piece_correction_entry(pos).at(us).minor << minBonus;
+    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << npwBonus;
+    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << npwBonus;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
+    const int    bonus2 = (bonus * 31 * 126 / 128) * mask;
+    const int    bonus4 = (bonus * 31 * 63 / 128) * mask;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
@@ -611,7 +615,7 @@ void Search::Worker::clear() {
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
-            h.fill(6);
+            h.fill(6 * 31);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})
@@ -1497,7 +1501,7 @@ moves_loop:  // When in check, search starts here
     {
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
-                     -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                     -CORRECTION_HISTORY_LIMIT / (4 * 31), CORRECTION_HISTORY_LIMIT / (4 * 31));
         update_correction_history(pos, ss, *this, 1069 * bonus / 1024);
     }
 


### PR DESCRIPTION
## Summary

- Raises CORRECTION_HISTORY_LIMIT from 1024 to 31744 (K=31), using 97% of the int16 range instead of 3%
- Scales all write bonuses by 31 in update_correction_history to preserve convergence semantics
- Scales read weights down by 31 in correction_value (131072 divisor unchanged, power-of-2 preserved)
- Fixes the contCorr4 truncation bug as a side effect: bonus=1 now writes 14 instead of 0

## Technical Details

K-scaling is semantics-preserving: the bonus/D ratio is unchanged, so entries converge at the same fractional rate. Near-saturation dirty-write frequency is identical to K=1.

Overflow analysis: max correction_value intermediate = 411 * 2 * 31744 = 26M (fits int32). Max write intermediate = 256 * 5611 = 1.4M (fits int32). Max gravity intermediate = 31744 * 7936 = 252M (fits int32).

The clamp stays at +-256 via CORRECTION_HISTORY_LIMIT / (4 * 31).

## Bench

Bench: 2484889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased correction-history capacity and adjusted internal weighting/scaling used during move evaluation.
  * Refined how pawn and non-pawn continuations are weighted and how bonuses propagate, improving consistency of correction adjustments and overall engine evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->