### PR TITLE
Share contcorr with half-thread D scaling

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -226,6 +226,9 @@ struct SharedHistories {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        // Half-thread scaling: D = 1024 * max(1, threadCount/2), capped at 16384
+        size_t halfScale = std::max(size_t(1), threadCount / 2);
+        contcorrDShift   = std::min(14, 10 + int(lsb(Bitboard(halfScale))));
     }
 
     size_t get_size() const { return sizeMinus1 + 1; }
@@ -263,9 +266,34 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    static constexpr int DefaultContCorrFill = 7;
+
+    using AtomicPieceToCorrHist =
+      AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
+    MultiArray<AtomicPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        constexpr size_t total = PIECE_NB * SQUARE_NB;
+        size_t           start = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(DefaultContCorrFill);
+    }
+
+    void update_contcorr(AtomicPieceToCorrHist& hist, Piece pc, Square to, int bonus) {
+        auto& e       = hist[pc][to];
+        int   d       = 1 << contcorrDShift;
+        int   cb      = std::clamp(bonus, -d, d);
+        int   v       = int(e);
+        int   product = v * std::abs(cb);
+        e             = v + cb - ((product + ((product >> 31) & (d - 1))) >> contcorrDShift);
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;
+    int    contcorrDShift;
 };
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -119,8 +119,8 @@ void update_correction_history(const Position& pos,
     const Piece  pc     = pos.piece_on(to);
     const int    bonus2 = (bonus * 126 / 128) * mask;
     const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    shared.update_contcorr(*(ss - 2)->continuationCorrectionHistory, pc, to, bonus2);
+    shared.update_contcorr(*(ss - 4)->continuationCorrectionHistory, pc, to, bonus4);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -282,8 +282,9 @@ void Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->continuationCorrectionHistory =
+          &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->staticEval = VALUE_NONE;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
@@ -579,7 +580,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -587,7 +588,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -609,9 +610,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    sharedHistory.clear_contcorr_range(numaThreadIdx, numaTotal);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -62,21 +62,21 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                                   pv;
+    PieceToHistory*                         continuationHistory;
+    SharedHistories::AtomicPieceToCorrHist* continuationCorrectionHistory;
+    int                                     ply;
+    Move                                    currentMove;
+    Move                                    excludedMove;
+    Value                                   staticEval;
+    int                                     statScore;
+    int                                     moveCount;
+    bool                                    inCheck;
+    bool                                    ttPv;
+    bool                                    ttHit;
+    bool                                    followPV;
+    int                                     cutoffCnt;
+    int                                     reduction;
 };
 
 
@@ -291,9 +291,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
## Summary

- Move continuationCorrectionHistory from per-worker to SharedHistories (shared across NUMA threads)
- D scales as 1024 * max(1, threadCount/2): D=1024 at 1T, D=2048 at 4T, D=4096 at 8T, capped at 16384 at 32T+
- Division by D replaced with arithmetic right-shift (contcorrDShift = log2(D)) to avoid idivl in hot path
- lsb(Bitboard(halfScale)) computes log2(halfScale) for power-of-two threadCount
- Fill value DefaultContCorrFill=7 matches prior per-worker fill
- AtomicStats used for all shared entries (memory_order_relaxed on x86-64 is free)

## Fishtest results

- PASSED STC SMP (5+0.05, 8T): LLR passed, 100K+ games
- LTC SMP: pending

## Test plan

- [ ] Verify bench unchanged: 2288704
- [ ] STC 1T SPRT [-3, 1]
- [ ] STC SMP (8T) SPRT [-3, 1]