### PR TITLE
Scale pawn history by K=3, D from 8192 to 24576

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -151,7 +151,7 @@ using ContinuationHistory = MultiArray<PieceToHistory, PIECE_NB, SQUARE_NB>;
 
 // PawnHistory is addressed by the pawn structure and a move's [piece][to]
 using PawnHistory =
-  DynStats<AtomicStats<std::int16_t, 8192, PIECE_NB, SQUARE_NB>, PAWN_HISTORY_BASE_SIZE>;
+  DynStats<AtomicStats<std::int16_t, 8192 * 3, PIECE_NB, SQUARE_NB>, PAWN_HISTORY_BASE_SIZE>;
 
 // Correction histories record differences between the static evaluation of
 // positions and their search score. It is used to improve the static evaluation

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -159,7 +159,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
         {
             // histories
             m.value = 2 * (*mainHistory)[us][m.raw()];
-            m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
+            m.value += (2 * sharedHistory->pawn_entry(pos)[pc][to]) / 3;
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -605,7 +605,7 @@ void Search::Worker::clear() {
 
     // Each thread is responsible for clearing their part of shared history
     sharedHistory.correctionHistory.clear_range(0, numaThreadIdx, numaTotal);
-    sharedHistory.pawnHistory.clear_range(-1238, numaThreadIdx, numaTotal);
+    sharedHistory.pawnHistory.clear_range(-1238 * 3, numaThreadIdx, numaTotal);
 
     ttMoveHistory = 0;
 
@@ -883,7 +883,7 @@ Value Search::Worker::search(
         mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12 * 3;
     }
 
 
@@ -1103,7 +1103,7 @@ moves_loop:  // When in check, search starts here
             {
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
-                            + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
+                            + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()] / 3;
 
                 // Continuation history based pruning
                 if (history < -4097 * depth)
@@ -1461,7 +1461,8 @@ moves_loop:  // When in check, search starts here
         mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq]
+              << scaledBonus * 290 * 3 / 8192;
     }
 
     // Bonus for prior capture countermove that caused the fail low
@@ -1930,7 +1931,7 @@ void update_quiet_histories(
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 
     workerThread.sharedHistory.pawn_entry(pos)[pos.moved_piece(move)][move.to_sq()]
-      << bonus * (bonus > 0 ? 974 : 543) / 1024;
+      << bonus * (bonus > 0 ? 974 : 543) * 3 / 1024;
 }
 
 }


### PR DESCRIPTION
Scale PawnHistory D from 8192 to 8192*3=24576, using 75% of int16 range vs prior 25%.

All write bonuses multiplied by 3 (explicit *3 in each formula); all read sites divided by 3 (explicit /3). Fill value scaled from -1238 to -1238*3 to preserve the same cold-start fraction of D. Convergence rate (bonus/D ratio) and move ordering balance are unchanged.

Precision fix: bonus*967/1024 and bonus*535/1024 now yield nonzero writes for bonus=1 (previously rounded to 0).

Non-conflicting with corr-hist-k31, butterfly-k4, and capture-k3 branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted pawn history evaluation scaling to improve move ordering accuracy and engine strength. Modified how pawn-related historical information is weighted in move evaluation across multiple assessment paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->