### PR TITLE
Scale low-ply history by K=4, D from 7183 to 28732

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -136,7 +136,7 @@ using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZ
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+using LowPlyHistory = Stats<std::int16_t, 7183 * 4, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (4 * (1 + ply));
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -311,7 +311,7 @@ void Search::Worker::iterative_deepening() {
 
     int searchAgainCounter = 0;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill(98 * 4);
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1925,7 +1925,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 * 4 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Scale LowPlyHistory from D=7183 to D=28732 (K=4, maximum K for int16).

K_max = floor(32767 / 7183) = 4. New D = 28732 (87.7% of int16 range).

Changes (K-scaling pattern, same as butterfly-k4):
- history.h: D multiplied by 4
- search.cpp fill: 98 -> 392 (= 98 * 4)
- search.cpp write: bonus * 682 / 1024 -> bonus * 682 * 4 / 1024
- movepick.cpp read: 8 * val / (1 + ply) -> 8 * val / (4 * (1 + ply))

Convergence rate (bonus/D) is unchanged. Higher precision reduces zero-write frequency for small bonuses.

Bench: 2689030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal move selection and evaluation parameters to improve search quality and consistency during engine computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->