### PR TITLE
K=3 correction history only: fix precision loss in contCorr2/contCorr4

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -35,11 +35,13 @@
 
 namespace Stockfish {
 
-constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
-constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
-constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
-constexpr int CORRECTION_HISTORY_LIMIT = 1024;
-constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+constexpr int PAWN_HISTORY_BASE_SIZE        = 8192;  // has to be a power of 2
+constexpr int UINT_16_HISTORY_SIZE          = std::numeric_limits<uint16_t>::max() + 1;
+constexpr int CORRHIST_BASE_SIZE            = UINT_16_HISTORY_SIZE;
+constexpr int CORRECTION_HISTORY_K          = 3;
+constexpr int CORRECTION_HISTORY_BASE_LIMIT = 1024;
+constexpr int CORRECTION_HISTORY_LIMIT      = CORRECTION_HISTORY_BASE_LIMIT * CORRECTION_HISTORY_K;
+constexpr int LOW_PLY_HISTORY_SIZE          = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -87,9 +87,11 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+                  : 8 * CORRECTION_HISTORY_K;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    // Stored entries are K times larger; divide sum by K to preserve output scale
+    return (12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv)
+         / CORRECTION_HISTORY_K;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -108,17 +110,20 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    const int scaledBonus = bonus * CORRECTION_HISTORY_K;
+    shared.pawn_correction_entry(pos).at(us).pawn << scaledBonus;
+    shared.minor_piece_correction_entry(pos).at(us).minor << scaledBonus * 153 / 128;
+    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite
+      << scaledBonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack
+      << scaledBonus * nonPawnWeight / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
+    const int    bonus2 = (scaledBonus * 126 / 128) * mask;
+    const int    bonus4 = (scaledBonus * 63 / 128) * mask;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
@@ -611,7 +616,7 @@ void Search::Worker::clear() {
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
-            h.fill(6);
+            h.fill(6 * CORRECTION_HISTORY_K);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})
@@ -1497,7 +1502,7 @@ moves_loop:  // When in check, search starts here
     {
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
-                     -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                     -CORRECTION_HISTORY_BASE_LIMIT / 4, CORRECTION_HISTORY_BASE_LIMIT / 4);
         update_correction_history(pos, ss, *this, 1069 * bonus / 1024);
     }
 


### PR DESCRIPTION
## Summary

- Add CORRECTION_HISTORY_K=3; raise CORRECTION_HISTORY_LIMIT from 1024 to 3072
- All correction write bonuses scaled via scaledBonus = bonus * CORRECTION_HISTORY_K
- correction_value() sum divided by CORRECTION_HISTORY_K (K cancels in read path: stored*W/(K*D) = semantic*W/D)
- Move-ordering tables unchanged (butterfly, capture, pawn, lowPly, contHist)

Fixes precision loss in contCorr2 (bonus*126/128=0 for bonus=1,2) and contCorr4 (bonus*63/128=0 for bonus=1,2).
K=3 is the minimum fix: scaledBonus=3 -> 3*63/128=1 (nonzero). Move-ordering balance undisturbed.
Correction read path: the K in stored entries and K in divisor cancel exactly.

## Bench

2979774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal correction-history scaling and capacity to preserve score scaling and improve stability of move evaluation.
  * Updated how correction values are initialized and clamped so historical adjustments remain consistent across searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->