### PR TITLE
Dynamic null move reduction based on eval-beta gap

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,8 +915,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and eval-beta gap
+        Depth R = std::clamp(int(eval - beta) / 213, 0, 6) + depth / 3 + 5;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Dynamic null move reduction: R depends on eval-beta gap.

R = std::clamp(int(eval - beta) / 213, 0, 6) + depth / 3 + 5

When eval is close to beta, R is lower (more conservative null move).
When eval is far above beta, R is higher (more aggressive pruning).
Clamped to [0, 6] to prevent negative values.

Original idea by FauziAkram (dipd branch).
Clamp fix applied to avoid negative R at positions where
correction history pushes eval below beta.

Reference: https://github.com/official-stockfish/Stockfish/discussions/6671

Bench: 2870604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced search algorithm evaluation to improve move assessment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->