### PR TITLE
Instrument dipd-clamp correction delta distribution

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>
@@ -63,6 +64,65 @@ void syzygy_extend_pv(const OptionsMap&            options,
 using namespace Search;
 
 namespace {
+
+enum TableId {
+    PAWN_CORR,
+    MINOR_CORR,
+    NONPAWN_W_CORR,
+    NONPAWN_B_CORR,
+    CONT_CORR_2,
+    CONT_CORR_4,
+    NUM_TABLES
+};
+static const char* TableName[] = {"pawnCorr", "minorCorr", "nonpawnW",
+                                  "nonpawnB", "contCorr2", "contCorr4"};
+
+struct DeltaCounters {
+    uint64_t bins[NUM_TABLES][11] = {};
+    uint64_t total[NUM_TABLES]    = {};
+};
+static thread_local DeltaCounters tlCounters;
+static constexpr int              MAX_THREADS = 256;
+static DeltaCounters              threadCounters[MAX_THREADS];
+static std::atomic<int>           threadSlot{0};
+static thread_local int           mySlot = -1;
+
+void record_delta(TableId tbl, int delta) {
+    int bin;
+    if (delta == 0)
+        bin = 0;
+    else if (delta == 1)
+        bin = 1;
+    else if (delta == 2)
+        bin = 2;
+    else if (delta == 3)
+        bin = 3;
+    else if (delta <= 5)
+        bin = 4;
+    else if (delta <= 9)
+        bin = 5;
+    else if (delta <= 19)
+        bin = 6;
+    else if (delta <= 49)
+        bin = 7;
+    else if (delta <= 99)
+        bin = 8;
+    else if (delta <= 199)
+        bin = 9;
+    else
+        bin = 10;
+    tlCounters.bins[tbl][bin]++;
+    tlCounters.total[tbl]++;
+}
+
+template<typename Entry>
+void instrument_write(TableId tbl, Entry& entry, int bonus, int D) {
+    int     clampedBonus = std::clamp(bonus, -D, D);
+    int16_t val          = static_cast<int16_t>(entry);
+    int16_t newval       = val + clampedBonus - val * std::abs(clampedBonus) / D;
+    record_delta(tbl, std::abs(newval - val));
+    entry << bonus;
+}
 
 constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
@@ -108,10 +168,15 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    instrument_write(PAWN_CORR, shared.pawn_correction_entry(pos).at(us).pawn, bonus, 1024);
+    instrument_write(MINOR_CORR, shared.minor_piece_correction_entry(pos).at(us).minor,
+                     bonus * 153 / 128, 1024);
+    instrument_write(NONPAWN_W_CORR,
+                     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite,
+                     bonus * nonPawnWeight / 128, 1024);
+    instrument_write(NONPAWN_B_CORR,
+                     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack,
+                     bonus * nonPawnWeight / 128, 1024);
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());
@@ -119,8 +184,8 @@ void update_correction_history(const Position& pos,
     const Piece  pc     = pos.piece_on(to);
     const int    bonus2 = (bonus * 126 / 128) * mask;
     const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    instrument_write(CONT_CORR_2, (*(ss - 2)->continuationCorrectionHistory)[pc][to], bonus2, 1024);
+    instrument_write(CONT_CORR_4, (*(ss - 4)->continuationCorrectionHistory)[pc][to], bonus4, 1024);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -150,7 +215,72 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
         && (ss - 2)->currentMove.from_sq() == (ss - 4)->currentMove.to_sq();
 }
 
+void flush_thread_counters() {
+    if (mySlot < 0)
+        mySlot = threadSlot.fetch_add(1, std::memory_order_relaxed);
+    if (mySlot < MAX_THREADS)
+        threadCounters[mySlot] = tlCounters;
+}
+
 }  // namespace
+
+void print_delta_report() {
+    flush_thread_counters();
+
+    // Aggregate all thread slots
+    DeltaCounters agg    = {};
+    int           nSlots = threadSlot.load(std::memory_order_relaxed);
+    if (nSlots > MAX_THREADS)
+        nSlots = MAX_THREADS;
+    for (int s = 0; s < nSlots; s++)
+    {
+        for (int t = 0; t < NUM_TABLES; t++)
+        {
+            agg.total[t] += threadCounters[s].total[t];
+            for (int b = 0; b < 11; b++)
+                agg.bins[t][b] += threadCounters[s].bins[t][b];
+        }
+    }
+
+    // CSV header
+    static bool headerPrinted = false;
+    if (!headerPrinted)
+    {
+        std::cout
+          << "depth,table,total_writes,d0,d1,d2,d3,d4_5,d6_9,d10_19,d20_49,d50_99,d100_199,d200p"
+          << std::endl;
+        headerPrinted = true;
+    }
+
+    // Depth from BENCH_DEPTH env var set by the sweep runner, or 0 if not set
+    const char* depthEnv   = std::getenv("BENCH_DEPTH");
+    int         benchDepth = depthEnv ? std::atoi(depthEnv) : 0;
+
+    // CSV output using fixed-point integer math
+    for (int t = 0; t < NUM_TABLES; t++)
+    {
+        uint64_t tot = agg.total[t];
+        if (tot == 0)
+            continue;
+        std::cout << benchDepth << "," << TableName[t] << "," << tot;
+        for (int b = 0; b < 11; b++)
+        {
+            uint64_t bps = agg.bins[t][b] * 1000000ULL / tot;
+            char     buf[20];
+            snprintf(buf, sizeof(buf), ",%llu.%04llu", (unsigned long long) (bps / 10000),
+                     (unsigned long long) (bps % 10000));
+            std::cout << buf;
+        }
+        std::cout << std::endl;
+    }
+
+    // Reset all slots and counter so threads get fresh slot assignments next run
+    for (int s = 0; s < nSlots; s++)
+        threadCounters[s] = DeltaCounters{};
+    tlCounters = DeltaCounters{};
+    mySlot     = -1;
+    threadSlot.store(0, std::memory_order_relaxed);
+}
 
 Search::Worker::Worker(SharedState&                    sharedState,
                        std::unique_ptr<ISearchManager> sm,
@@ -188,6 +318,7 @@ void Search::Worker::start_searching() {
     if (!is_mainthread())
     {
         iterative_deepening();
+        flush_thread_counters();
         return;
     }
 
@@ -205,6 +336,7 @@ void Search::Worker::start_searching() {
     {
         threads.start_searching();  // start non-main threads
         iterative_deepening();      // main thread start searching
+        flush_thread_counters();
     }
 
     // When we reach the maximum depth, we can arrive here without a raise of
@@ -915,8 +1047,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and eval-beta gap
+        Depth R = std::clamp(int(eval - beta) / 213, 0, 6) + depth / 3 + 5;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -42,6 +42,9 @@
 
 namespace Stockfish {
 
+// Forward declaration for instrumentation reporting (defined in search.cpp)
+void print_delta_report();
+
 constexpr auto BenchmarkCommand = "speedtest";
 
 constexpr auto StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
@@ -244,6 +247,23 @@ void UCIEngine::bench(std::istream& args) {
     num = count_if(list.begin(), list.end(),
                    [](const std::string& s) { return s.find("go ") == 0 || s.find("eval") == 0; });
 
+    // Suppress stderr during bench to avoid pipe buffer issues at high depths.
+    // RAII guard restores rdbuf on scope exit even if an exception is thrown.
+    struct StderrGuard {
+        std::streambuf* saved;
+        bool            restored = false;
+        StderrGuard() :
+            saved(std::cerr.rdbuf(nullptr)) {}
+        void restore() {
+            if (!restored)
+            {
+                std::cerr.rdbuf(saved);
+                restored = true;
+            }
+        }
+        ~StderrGuard() { restore(); }
+    } stderrGuard;
+
     TimePoint elapsed = now();
 
     for (const auto& cmd : list)
@@ -253,8 +273,7 @@ void UCIEngine::bench(std::istream& args) {
 
         if (token == "go" || token == "eval")
         {
-            std::cerr << "\nPosition: " << cnt++ << '/' << num << " (" << engine.fen() << ")"
-                      << std::endl;
+            cnt++;
             if (token == "go")
             {
                 Search::LimitsType limits = parse_limits(is);
@@ -286,7 +305,12 @@ void UCIEngine::bench(std::istream& args) {
 
     elapsed = now() - elapsed + 1;  // Ensure positivity to avoid a 'divide by zero'
 
+    stderrGuard.restore();  // Restore stderr before printing summary
+
     dbg_print();
+
+    // Print per-table delta instrumentation report
+    print_delta_report();
 
     std::cerr << "\n==========================="    //
               << "\nTotal time (ms) : " << elapsed  //


### PR DESCRIPTION
Instrumentation of dipd-clamp branch correction history delta distribution.
No zero-delta skip -- all writes are recorded including zero-delta ones,
preserving original search behavior.

dipd-clamp change: R = std::clamp(int(eval - beta) / 213, 0, 6) + depth / 3 + 5
Instrumentation from stockfish-instrumentation repo.

References:
- dipd-clamp (non-instrumented): PR #50
- Discussion: https://github.com/official-stockfish/Stockfish/discussions/6671

Bench: 0000000 (instrumentation-only, not for submission)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modified null-move reduction logic in the search algorithm for improved efficiency
  * Enhanced internal instrumentation and delta reporting system
  * Refined benchmark output handling and reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->