### PR TITLE
Increase null move reduction when position is improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,8 +915,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and improving
+        Depth R = 7 + depth / 3 + improving;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Add improving flag to null move reduction formula.

R = 7 + depth / 3 + improving

When the position is improving (staticEval better than 2 plies ago), add 1 extra
ply of reduction. This makes null move pruning more aggressive in positions where
we are gaining ground, which is when the null move is most likely to succeed.

R is always >= master (never less pruning). At most 1 extra ply of reduction.

Original idea by FauziAkram (Fauzi2), dipd1 branch.

Reference: https://github.com/official-stockfish/Stockfish/discussions/6671

Bench: 3030480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search depth evaluation for improved move assessment accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->