### PR TITLE
Extra null move reduction when eval far above beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,8 +915,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and eval-beta gap
+        Depth R = 7 + depth / 3 + std::clamp((int(eval - beta) - 426) / 213, 0, 4);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Add extra null move reduction when eval is significantly above beta.

R = 7 + depth / 3 + std::clamp((int(eval - beta) - 426) / 213, 0, 4)

When eval - beta <= 426: R equals master (no change).
When eval - beta > 426: R increases by 1-4 plies (more aggressive pruning).
R is always >= master, never less.

This is a v2 of dipd-clamp (PR #50) which had R_min 2 below master, causing
equal LD losses and WW gains that canceled to ~0 Elo. v2 eliminates the LD
losses by keeping master as the floor.

Original idea by FauziAkram (Fauzi2).

Reference: https://github.com/official-stockfish/Stockfish/discussions/6671

Bench: 3236983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved null-move search algorithm efficiency through adaptive reduction calculation based on position evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->