### PR TITLE
Extra null move reduction for eval above beta and improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,8 +915,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth, eval-beta gap, and improving
+        Depth R = 7 + depth / 3 + std::clamp((int(eval - beta) - 426) / 213, 0, 4) + improving;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Combine eval-beta gap and improving flag for null move reduction.

R = 7 + depth / 3 + std::clamp((int(eval - beta) - 426) / 213, 0, 4) + improving

Two independent signals added to master baseline:
1. When eval - beta > 426: add 1-4 extra plies (from dipd-clamp-v2, PR #53)
2. When position is improving: add 1 extra ply (from dipd1, PR #52)

R is always >= master. Maximum extra reduction is 5 plies (4 from eval gap + 1 from improving).

Original idea by FauziAkram (Fauzi2).

Note: this is a combo of dipd-clamp-v2 + dipd1 for testing purposes only.
If positive, the individual components should be tested separately on Fishtest.

Reference: https://github.com/official-stockfish/Stockfish/discussions/6671

Bench: 2925393