### PR TITLE
Add last-move correction history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -171,12 +171,14 @@ struct CorrectionBundle {
     StatsEntry<T, D, true> minor;
     StatsEntry<T, D, true> nonPawnWhite;
     StatsEntry<T, D, true> nonPawnBlack;
+    StatsEntry<T, D, true> lastMove;
 
     void operator=(T val) {
         pawn         = val;
         minor        = val;
         nonPawnWhite = val;
         nonPawnBlack = val;
+        lastMove     = val;
     }
 };
 
@@ -258,6 +260,13 @@ struct SharedHistories {
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+
+    auto& lastmove_correction_entry(Move m) {
+        return correctionHistory[make_key(m.raw()) & sizeMinus1];
+    }
+    const auto& lastmove_correction_entry(Move m) const {
+        return correctionHistory[make_key(m.raw()) & sizeMinus1];
     }
 
     UnifiedCorrectionHistory correctionHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,12 +84,13 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
+    const int   lmcv   = m.is_ok() ? int(shared.lastmove_correction_entry(m).at(us).lastMove) : 0;
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7000 * lmcv + 7982 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -112,6 +113,9 @@ void update_correction_history(const Position& pos,
     shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+
+    if (m.is_ok())
+        shared.lastmove_correction_entry(m).at(us).lastMove << bonus * 140 / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());


### PR DESCRIPTION
## Summary
- Add correction history indexed by previous ply raw move via make_key()
- Captures move-specific eval biases (from_sq, to_sq, move type)
- Complements continuation correction (which uses piece-on-target from ss-2/ss-4)
- Read weight 7000, write weight 140/128, conditional on m.is_ok()

## Test plan
- [ ] Cutechess SPRT on hw2
- [ ] Fishtest STC if cutechess positive

Bench: 2734293