### PR TITLE
Add check threat correction history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -171,12 +171,14 @@ struct CorrectionBundle {
     StatsEntry<T, D, true> minor;
     StatsEntry<T, D, true> nonPawnWhite;
     StatsEntry<T, D, true> nonPawnBlack;
+    StatsEntry<T, D, true> checkThreat;
 
     void operator=(T val) {
         pawn         = val;
         minor        = val;
         nonPawnWhite = val;
         nonPawnBlack = val;
+        checkThreat  = val;
     }
 };
 
@@ -258,6 +260,15 @@ struct SharedHistories {
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+
+    auto& check_threat_correction_entry(const Position& pos, Color us) {
+        Key k = make_key(uint64_t(pos.blockers_for_king(~us)));
+        return correctionHistory[k & sizeMinus1];
+    }
+    const auto& check_threat_correction_entry(const Position& pos, Color us) const {
+        Key k = make_key(uint64_t(pos.blockers_for_king(~us)));
+        return correctionHistory[k & sizeMinus1];
     }
 
     UnifiedCorrectionHistory correctionHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,12 +84,13 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
+    const int   chkcv  = shared.check_threat_correction_entry(pos, us).at(us).checkThreat;
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7000 * chkcv + 7982 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -112,6 +113,7 @@ void update_correction_history(const Position& pos,
     shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.check_threat_correction_entry(pos, us).at(us).checkThreat << bonus * 140 / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());


### PR DESCRIPTION
## Summary
- Add correction history indexed by blockers_for_king(~us)
- Captures discovered check potential and pin patterns
- correction_value is skipped when inCheck, so checkers() would be useless
- blockers_for_king captures check THREAT in non-check positions
- Read weight 7000, write weight 140/128

## Test plan
- [ ] Cutechess SPRT on hw2
- [ ] Fishtest STC if cutechess positive

Bench: 3045890