### PR TITLE
Reduce LMR less for check-giving moves continuing check sequence

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1243,6 +1243,10 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
 
+        // Reduce less for check-giving moves that continue a check sequence
+        if (givesCheck && (ss - 1)->inCheck)
+            r -= 1024;
+
         // Scale up reductions for expected ALL nodes
         if (allNode)
             r += r * 273 / (256 * depth + 260);


### PR DESCRIPTION
Reduce LMR reduction for moves that give check when the side already gave check 2 plies ago, recognizing consecutive check sequences as tactically important. Bench: 2823056