### PR TITLE
Add ss-3 lookback to continuation correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,10 +84,18 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+
+        cntcv = (*(ss - 2)->continuationCorrectionHistory)[pc][sq]
+              + (*(ss - 3)->continuationCorrectionHistory)[pc][sq]
+              + (*(ss - 4)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -117,9 +125,11 @@ void update_correction_history(const Position& pos,
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
+    const int    bonus2 = (bonus * 128 / 128) * mask;
+    const int    bonus3 = (bonus * 90 / 128) * mask;
+    const int    bonus4 = (bonus * 64 / 128) * mask;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
+    (*(ss - 3)->continuationCorrectionHistory)[pc][to] << bonus3;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
 


### PR DESCRIPTION
Add ss-3 (opponent move 3 plies back) to continuation correction read and write. Write weight 90/128 (between ss-2 at 126/128 and ss-4 at 63/128). Sirius uses 6 plies; this tests whether the odd-ply opponent move signal adds value. Bench: 2956006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal move-evaluation logic and history tracking to produce more consistent and accurate continuation estimates, enhancing decision stability and overall engine play quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->