### PR TITLE
Reduce consecutive checks when eval near draw

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1243,6 +1243,10 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
 
+        // Reduce check-giving moves in a check sequence when eval is near draw
+        if (givesCheck && (ss - 1)->inCheck && std::abs(eval) < 200)
+            r += 1024;
+
         // Scale up reductions for expected ALL nodes
         if (allNode)
             r += r * 273 / (256 * depth + 260);


### PR DESCRIPTION
Reduce check-giving moves in consecutive check sequence only when abs(eval) < 200.
Eval gate filters tactical positions, targets likely perpetuals.

Bench: 3353078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved search efficiency in specific game position scenarios involving consecutive checks and near-draw evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->