### PR TITLE
Heavier reduction for consecutive check sequences

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1243,6 +1243,10 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
 
+        // Reduce more for check-giving moves in check sequence (likely perpetual)
+        if (givesCheck && (ss - 1)->inCheck)
+            r += 2048;
+
         // Scale up reductions for expected ALL nodes
         if (allNode)
             r += r * 273 / (256 * depth + 260);


### PR DESCRIPTION
Like consec-check-more-reduce but with 2x coefficient (r += 2048 vs 1024).
More aggressive reduction assuming consecutive checks are perpetual.

Bench: 2977581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized move-reduction logic in the search algorithm for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->