### PR TITLE
Compact contCorr int8 with read multiplier K=8

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -39,6 +39,8 @@ constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
 constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
+constexpr int CONTCORR_LIMIT           = std::numeric_limits<std::int8_t>::max();
+constexpr int CONTCORR_READ_MULTIPLIER = 8;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
@@ -180,6 +182,8 @@ struct CorrectionBundle {
     }
 };
 
+using ContCorrEntry = Stats<std::int8_t, CONTCORR_LIMIT, PIECE_NB, SQUARE_NB>;
+
 namespace Detail {
 
 template<CorrHistType>
@@ -195,7 +199,7 @@ struct CorrHistTypedef<PieceTo> {
 
 template<>
 struct CorrHistTypedef<Continuation> {
-    using type = MultiArray<CorrHistTypedef<PieceTo>::type, PIECE_NB, SQUARE_NB>;
+    using type = MultiArray<ContCorrEntry, PIECE_NB, SQUARE_NB>;
 };
 
 template<>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,8 +85,9 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
     const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+      m.is_ok() ? ((*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+                   + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()])
+                    * CONTCORR_READ_MULTIPLIER
                   : 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;

--- a/src/search.h
+++ b/src/search.h
@@ -62,21 +62,21 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*           pv;
+    PieceToHistory* continuationHistory;
+    ContCorrEntry*  continuationCorrectionHistory;
+    int             ply;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    int             statScore;
+    int             moveCount;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
+    int             cutoffCnt;
+    int             reduction;
 };
 
 


### PR DESCRIPTION
Compress continuation correction history from int16 to int8 with D=127 and
read multiplier K=8 to restore original scale. ContCorr has the lowest read
weight (7982) among correction tables, minimizing quantization impact.
Halves contCorr memory from 1.8 MB to 900 KB per worker.

Bench: 3142959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized continuation-correction data handling to reduce memory use and improve evaluation performance during move search.
* **Bug Fix**
  * Adjusted how continuation-correction values are read and applied, producing more consistent correction contributions in move scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->