### PR TITLE
Reduce LMR along predicted PV line from previous iteration

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1216,6 +1216,10 @@ moves_loop:  // When in check, search starts here
         r -= moveCount * 65;
         r -= std::abs(correctionValue) / 25600;
 
+        // Reduce less along the predicted PV line from previous iteration
+        if (ss->followPV)
+            r -= 1024;
+
         // Increase reduction for cut nodes
         if (cutNode)
             r += 3611 + 985 * !ttData.move;


### PR DESCRIPTION
Reduce LMR by 1 ply (r -= 1024) on nodes marked by the followPV flag,
which tracks the principal variation from the previous search iteration.
The followPV infrastructure was added in e20ef7ed with an explicit invitation
for use in additional pruning techniques.

Bench: 3491876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized search depth reduction algorithm parameters to enhance move evaluation efficiency and improve search performance when evaluating moves along predicted variation lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->