### PR TITLE
Extra NMP reduction when correction history is large positive

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,8 +915,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and large positive correction
+        Depth R = 7 + depth / 3 + (correctionValue > 192 * 131072);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Increase null move reduction by 1 ply when correctionValue > 25165824
(~+192cp). When the NNUE underestimates the position by this much, the
position is stronger than eval indicates, so NMP can prune more aggressively.
This exploits the sign of correction, which is currently unused (only abs()
is used in futility, singular extension, and LMR).

Bench: 2972094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved search behavior by dynamically adjusting null-move reduction based on position evaluation, leading to more accurate pruning and verification in engine analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->