### PR TITLE
Add ss-1 contcorr with write weight 96/128

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,10 +84,18 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+
+        cntcv = (*(ss - 1)->continuationCorrectionHistory)[pc][sq]
+              + (*(ss - 2)->continuationCorrectionHistory)[pc][sq]
+              + (*(ss - 4)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -117,8 +125,10 @@ void update_correction_history(const Position& pos,
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
+    const int    bonus1 = (bonus * 96 / 128) * mask;
+    const int    bonus2 = (bonus * 128 / 128) * mask;
+    const int    bonus4 = (bonus * 64 / 128) * mask;
+    (*(ss - 1)->continuationCorrectionHistory)[pc][to] << bonus1;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }


### PR DESCRIPTION
Add continuation correction history at ss-1 (opponent's last move) with write weight 96/128.
Part of ss-1 weight sweep (20, 32, 64, 96, 128) to find optimal coefficient.

Bench: 3116067