### PR TITLE
Add ss-5 contcorr with loop and weight 32/128

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,10 +84,20 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        static constexpr std::array<int, 3> contcorr_plies = {2, 4, 5};
+
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+
+        cntcv = 0;
+        for (const auto i : contcorr_plies)
+            cntcv += (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -114,13 +124,14 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    static constexpr std::array<ContcorrBonus, 3> contcorr_write = {{{2, 128}, {4, 64}, {5, 32}}};
+
+    const int    mask = int(m.is_ok());
+    const Square to   = m.to_sq_unchecked();
+    const Piece  pc   = pos.piece_on(to);
+
+    for (const auto [i, weight] : contcorr_write)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (bonus * weight / 128) * mask;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,11 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrBonus {
+    int index;
+    int weight;
+};
+
 
 }  // namespace Search
 


### PR DESCRIPTION
Add ss-5 lookback to continuation correction history using loop-based
read/write with constexpr arrays (like update_continuation_histories).

Write weights: ss-2 128/128, ss-4 64/128, ss-5 32/128.
Read: equal weight summation of ss-2, ss-4, ss-5.

GCC fully unrolls both loops. ss-5 weight 32/128 compiles to shl+sar
(no imul). correction_value +8 bytes, update_correction_history +60 bytes.

Bench: 2560341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined continuation history correction calculations to improve position evaluation accuracy in the engine's search algorithm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->