### PR TITLE
Add ss-1 contcorr with loop and weight 71/128

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,10 +84,20 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        static constexpr std::array<int, 3> contcorr_plies = {1, 2, 4};
+
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+
+        cntcv = 0;
+        for (const auto i : contcorr_plies)
+            cntcv += (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -113,14 +123,14 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    static constexpr std::array<ContcorrBonus, 3> contcorr_write = {{{1, 71}, {2, 128}, {4, 64}}};
+
+    const int    cntBonus = bonus * m.is_ok();
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+
+    for (const auto [i, weight] : contcorr_write)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,11 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrBonus {
+    int index;
+    int weight;
+};
+
 
 }  // namespace Search
 


### PR DESCRIPTION
Add ss-1 lookback to continuation correction history with write weight 71/128.
Uses loop-based constexpr array and bonus * m.is_ok() pattern instead of
per-iteration mask multiply. GCC produces identical codegen for both patterns,
using branch to skip contcorr writes when move is invalid (hot path has zero
overhead). Bench: 2784209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal search computation logic, replacing ternary conditional expressions with explicit branch patterns for improved maintainability.
  * Reorganized the correction history update mechanism, transitioning from branchless masked conditional updates to a structured array-based iteration approach with weighted multipliers.
  * Added a supporting data structure with index and weight configuration fields to enhance internal search processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->