### PR TITLE
Move contcorr write-side weights to read-side

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,12 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Per-ply contcorr read weights; write uses uniform bonus (index only)
+constexpr std::array<Search::ContcorrWeight, 2> contcorr = {{{2, 10643}, {4, 5321}}};
+
+// Fallback cntcv when previous move is not valid
+constexpr int CONTCORR_FALLBACK = 63856;
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -84,12 +90,20 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+        cntcv = 0;
+        for (const auto& [i, weight] : contcorr)
+            cntcv += weight * (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = CONTCORR_FALLBACK;
+
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -113,14 +127,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    // Uniform write: per-ply differentiation is on the read side
+    const int    cntBonus = bonus * int(m.is_ok());
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+
+    for (const auto& [i, weight] : contcorr)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << cntBonus;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,10 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrWeight {
+    int index;
+    int weight;
+};
 
 }  // namespace Search
 


### PR DESCRIPTION
## Summary
- Move contcorr per-ply weight differentiation from write to read side
- Master uses asymmetric write weights (ss-2: 126/128, ss-4: 63/128) with a single read multiplier (7982)
- Branch uses uniform writes (full bonus for both plies) and per-ply read weights (ss-2: 10643, ss-4: 5321) in same 2:1 ratio
- At saturation: identical total contribution (10643 + 5321 = 2 * 7982 = 15964)
- Every other engine with multiple contcorr plies uses uniform writes with per-ply read weights; Stockfish is the only engine using write-side differentiation
- Enables future addition of new plies (ss-5, ss-3, ss-1) with independent read weights

## Test plan
- [x] Bench matches: 3211515
- [x] GCC fully unrolls read loop (imul 0x2993, imul 0x14c9)
- [ ] Cutechess SPRT on hw2 (queued)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the engine's continuation-correction logic: evaluation now reads weighted, per-ply history values and uses a unified update write for continuation history. This yields more consistent and efficient correction adjustments during search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->