### PR TITLE
Add ss-5 continuation correction with write weight 52/128

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,9 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Per-ply contcorr write weights; read uses uniform sum (index only)
+constexpr std::array<Search::ContcorrBonus, 3> contcorr_plies = {{{2, 128}, {4, 64}, {5, 52}}};
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -84,10 +87,18 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+
+        cntcv = 0;
+        for (const auto& [i, weight] : contcorr_plies)
+            cntcv += (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -113,14 +124,12 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    const int    cntBonus = bonus * m.is_ok();
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+
+    for (const auto [i, weight] : contcorr_plies)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,11 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrBonus {
+    int index;
+    int weight;
+};
+
 
 }  // namespace Search
 


### PR DESCRIPTION
## Summary

Add ss-5 (opponent's move before our move 2 turns ago) as a third continuation
correction history ply. Write weight 52/128 dampens convergence speed for the
sparsely-visited ss-5 entries, filtering noise while preserving signal.

Single shared contcorr_plies array at file scope used by both read and write:
- Read: iterates plies, sums entries uniformly (weight unused)
- Write: iterates plies, applies per-ply write weight

Cutechess STC: +2.31 Elo [-1.8, +6.5], LLR +0.59, 14K games (4 runs combined).

## Bench

2779810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved move evaluation and correction tracking to use a more consistent continuation-correction approach and broader ply coverage.
  * Adjusted how correction bonuses are accumulated and applied, improving stability and responsiveness of historical move adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->