### PR TITLE
Add write-only ss-5 to continuation correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,13 +114,14 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    // ss-5 is write-only (not read in correction_value)
+    static constexpr std::array<ConthistBonus, 3> contcorr_writes = {{{2, 126}, {4, 63}, {5, 52}}};
+
+    const int    cntBonus = bonus * int(m.is_ok());
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+    for (const auto& [i, weight] : contcorr_writes)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
## Summary
- Add ss-5 write to contcorr update without modifying the read side
- correction_value() remains identical to master (reads ss-2 and ss-4 only)
- ss-5 entry is trained as background data, improving table quality when the same piece-square pair is later read via ss-2 or ss-4 from a different position
- Follows the ContinuationHistory precedent where ply 5 is written but never read in MovePicker
- Write weights: ss-2=126, ss-4=63, ss-5=52 (all /128), using local constexpr ConthistBonus array

Bench: 3042354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined correction-history update logic for simpler, branchless computation and improved efficiency.
  * Consolidated legality checks into a single scaled update to reduce redundant work.
  * Added an additional update path to better capture continuation corrections while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->