### PR TITLE
Per-ply read coefficients for continuation correction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,12 +84,22 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    static constexpr ConthistBonus contcorr_reads[] = {{2, 10643}, {4, 5321}};
+
+    int cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+        cntcv         = 0;
+        for (const auto& [i, weight] : contcorr_reads)
+            cntcv += weight * (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = 4 * (contcorr_reads[0].weight + contcorr_reads[1].weight);
+
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation


### PR DESCRIPTION
## Summary
- Replace uniform cntcv read weight (7982) with per-ply coefficients: ss-2=10643, ss-4=5321 (2:1 ratio matching write weight ratio 126:63)
- Write side is UNCHANGED from master (per-ply write weights 126/128 and 63/128)
- At saturation: 10643*1024 + 5321*1024 = 16,347,136 = 7982*2048, same total as master
- Fallback for invalid moves: 63856 (= 7982 * 8, matching master)
- Uses local constexpr ConthistBonus array for tunability
- This is the read-side half of contcorr-readweight (which also changes write to uniform)

Bench: 2622530