### PR TITLE
Refactor contcorr writes to array-driven loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,14 +113,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    static constexpr ConthistBonus contcorr_writes[] = {{2, 126}, {4, 63}};
+
+    const int    cntBonus = bonus * int(m.is_ok());
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+    for (const auto& [i, weight] : contcorr_writes)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
## Summary
- Replace manual bonus2/bonus4 computations with a loop over a local constexpr ConthistBonus array
- Hoist mask multiplication into cntBonus = bonus * int(m.is_ok()) before the loop
- Same weights as master: {2, 126} and {4, 63}
- Array-driven structure makes weights easy to tune and extend with new plies

GCC 15.2 with PGO+LTO produces identical binary (same size: 96,218,231 bytes, same instruction count). The compiler already optimizes the mask hoisting and loop unrolling to match the manual code. This is a source-level refactoring only.

Bench: 3164843 (identical to master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal search correction history update mechanism for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->