### PR TITLE
Add write-only ss-1 contcorr with half weight

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,14 +113,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    static constexpr ConthistBonus contcorr_writes[] = {{1, 63}, {2, 126}, {4, 63}};
+
+    const int    cntBonus = bonus * int(m.is_ok());
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+    for (const auto& [i, weight] : contcorr_writes)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
Add ss-1 write-only entry to continuation correction history update.
Read path unchanged (ss-2 and ss-4 only). Write weights: ss-1=63/128,
ss-2=126/128, ss-4=63/128. Array-driven loop replaces manual bonus
variables. Bench identical to master.

Bench: 3164843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Internal optimization to continuation correction history computation for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->