### PR TITLE
Add ss-6 contcorr with per-ply read and write coefficients

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,12 +84,27 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    static constexpr ConthistBonus contcorr_reads[] = {{2, 10643}, {4, 5321}, {6, 2660}};
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    constexpr int contcorrFallback = 4;
+
+    int cntcv;
+    if (m.is_ok())
+    {
+        const Square sq = m.to_sq();
+        const Piece  pc = pos.piece_on(sq);
+        cntcv           = 0;
+        for (const auto& [i, weight] : contcorr_reads)
+            cntcv += weight * (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+    {
+        cntcv = 0;
+        for (const auto& [i, weight] : contcorr_reads)
+            cntcv += contcorrFallback * weight;
+    }
+
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -113,14 +128,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    static constexpr ConthistBonus contcorr_writes[] = {{2, 126}, {4, 63}, {6, 31}};
+
+    const int    cntBonus = bonus * int(m.is_ok());
+    const Square to       = m.to_sq_unchecked();
+    const Piece  pc       = pos.piece_on(to);
+    for (const auto& [i, weight] : contcorr_writes)
+        (*(ss - i)->continuationCorrectionHistory)[pc][to] << (cntBonus * weight / 128);
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
Combine per-ply read coefficients with ss-6 write into one branch.
Read weights: ss-2=10643, ss-4=5321, ss-6=2660 (geometric halving).
Write weights: ss-2=126/128, ss-4=63/128, ss-6=31/128.
Fallback uses loop-based weight sum with named contcorrFallback constant.

Bench: 3232962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced search algorithm's move evaluation by improving how continuation corrections are calculated and applied.
  * Refined the correction history update mechanism with optimized weighting calculations for more nuanced position assessments.
  * These internal improvements contribute to better move quality evaluation during search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->