### PR TITLE
ContHist-derived 5-ply contcorr with linear writes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,10 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+constexpr int                                   CONTCORR_FALLBACK = 63856;
+constexpr std::array<Search::ContcorrWeight, 5> contcorr          = {
+  {{2, 9304}, {3, 4065}, {4, 6660}, {5, 1532}, {6, 5363}}};
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -84,12 +88,19 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if (m.is_ok())
+    {
+        const auto sq = m.to_sq();
+        const auto pc = pos.piece_on(sq);
+        cntcv         = 0;
+        for (const auto& [i, weight] : contcorr)
+            cntcv += weight * (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+        cntcv = CONTCORR_FALLBACK;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -113,14 +124,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    if (m.is_ok())
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(to);
+        for (const auto& [i, weight] : contcorr)
+            (*(ss - i)->continuationCorrectionHistory)[pc][to] << bonus;
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,10 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrWeight {
+    int index;
+    int weight;
+};
 
 }  // namespace Search
 


### PR DESCRIPTION
5-ply contcorr (ss-2 through ss-6) with per-ply read weights derived from
ContHist write weights. No ss-1. Writes are linear (full bonus for all plies).
Read weights: ss-2=9304, ss-3=4065, ss-4=6660, ss-5=1532, ss-6=5363.

Bench: 3247459