### PR TITLE
NNZ bitmask with sentinel bit loop termination

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -251,7 +251,7 @@ class AffineTransformSparseInput {
     }
 
     // Forward propagation
-    void propagate(const InputType* input, OutputType* output) const {
+    void propagate(const InputType* input, const uint8_t* nnz, OutputType* output) const {
 
 #if (USE_SSSE3 | (USE_NEON >= 8))
     #if defined(USE_AVX512)
@@ -283,8 +283,7 @@ class AffineTransformSparseInput {
         #define vec_add_dpbusd_32 SIMD::neon_m128_add_dpbusd_epi32
     #endif
         constexpr IndexType OutputSimdWidth = sizeof(outvec_t) / sizeof(OutputType);
-        constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
-        constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
+        constexpr IndexType NumAccums       = OutputDimensions / OutputSimdWidth;
         // If we're using high-latency dot product instructions, split the accumulators
         // to create 3 separate dependency chains and merge at the end
         constexpr IndexType NumRegs =
@@ -293,61 +292,50 @@ class AffineTransformSparseInput {
     #else
           NumAccums;
     #endif
-        std::uint16_t nnz[NumChunks];
-        IndexType     count;
-
-        // Find indices of nonzero 32-bit blocks
-        find_nnz<NumChunks>(input, nnz, count);
-
         const outvec_t* biasvec = reinterpret_cast<const outvec_t*>(biases);
         outvec_t        acc[NumRegs];
         for (IndexType k = 0; k < NumAccums; ++k)
             acc[k] = biasvec[k];
 
-        const auto* start = nnz;
-        const auto* end   = nnz + count;
-
-        // convince GCC to not do weird pointer arithmetic in the following loop
-        const std::int8_t* weights_cp = weights;
-    #if defined(USE_VNNI)
-        for (IndexType k = NumAccums; k < NumRegs; ++k)
-            acc[k] = vec_zero();
-
-        while (start < end - 2)
+        if constexpr (InputDimensions == 128)
         {
-            const std::ptrdiff_t i0 = *start++;
-            const std::ptrdiff_t i1 = *start++;
-            const std::ptrdiff_t i2 = *start++;
-            const invec_t        in0 =
-              vec_set_32(load_as<std::int32_t>(input + i0 * sizeof(std::int32_t)));
-            const invec_t in1 =
-              vec_set_32(load_as<std::int32_t>(input + i1 * sizeof(std::int32_t)));
-            const invec_t in2 =
-              vec_set_32(load_as<std::int32_t>(input + i2 * sizeof(std::int32_t)));
-            const auto col0 =
-              reinterpret_cast<const invec_t*>(&weights_cp[i0 * OutputDimensions * ChunkSize]);
-            const auto col1 =
-              reinterpret_cast<const invec_t*>(&weights_cp[i1 * OutputDimensions * ChunkSize]);
-            const auto col2 =
-              reinterpret_cast<const invec_t*>(&weights_cp[i2 * OutputDimensions * ChunkSize]);
-            for (IndexType k = 0; k < NumAccums; ++k)
+            constexpr ptrdiff_t sentinel   = InputDimensions / ChunkSize;
+            const std::int8_t*  weights_cp = weights;
+            uint64_t            bits       = load_as<uint32_t>(nnz) | (uint64_t(1) << sentinel);
+
+            for (;;)
             {
-                vec_add_dpbusd_32(acc[k], in0, col0[k]);
-                vec_add_dpbusd_32(acc[k + NumAccums], in1, col1[k]);
-                vec_add_dpbusd_32(acc[k + 2 * NumAccums], in2, col2[k]);
+                ptrdiff_t i = pop_lsb(bits);
+                if (i >= sentinel)
+                    break;
+                const invec_t in =
+                  vec_set_32(load_as<std::int32_t>(input + i * sizeof(std::int32_t)));
+                const auto col =
+                  reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
+                for (IndexType l = 0; l < NumAccums; ++l)
+                    vec_add_dpbusd_32(acc[l], in, col[l]);
             }
         }
-        for (IndexType k = 0; k < NumAccums; ++k)
-            acc[k] = vec_add_32(vec_add_32(acc[k], acc[k + NumAccums]), acc[k + 2 * NumAccums]);
-    #endif
-        while (start < end)
+        else
         {
-            const std::ptrdiff_t i = *start++;
-            const invec_t in = vec_set_32(load_as<std::int32_t>(input + i * sizeof(std::int32_t)));
-            const auto    col =
-              reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
-            for (IndexType k = 0; k < NumAccums; ++k)
-                vec_add_dpbusd_32(acc[k], in, col[k]);
+            const std::int8_t* weights_cp = weights;
+            for (IndexType k = 0; k < InputDimensions / 256; ++k)
+            {
+                uint64_t  bits = load_as<uint64_t>(nnz + k * 8);
+                ptrdiff_t base = k * 64;
+                int       cnt  = popcount(bits);
+
+                for (int n = 0; n < cnt; ++n)
+                {
+                    ptrdiff_t     i = pop_lsb(bits) + base;
+                    const invec_t in =
+                      vec_set_32(load_as<std::int32_t>(input + i * sizeof(std::int32_t)));
+                    const auto col = reinterpret_cast<const invec_t*>(
+                      &weights_cp[i * OutputDimensions * ChunkSize]);
+                    for (IndexType l = 0; l < NumAccums; ++l)
+                        vec_add_dpbusd_32(acc[l], in, col[l]);
+                }
+            }
         }
 
         outvec_t* outptr = reinterpret_cast<outvec_t*>(output);

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -178,13 +178,14 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     alignas(alignment)
       TransformedFeatureType transformedFeatures[FeatureTransformer<FTDimensions>::BufferSize];
+    uint8_t                  nnz[sizeof(transformedFeatures) / 32];
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
     const auto psqt =
-      featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-    const auto positional = network[bucket].propagate(transformedFeatures);
+      featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket, nnz);
+    const auto positional = network[bucket].propagate(transformedFeatures, nnz);
     return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
 
@@ -247,9 +248,9 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
     t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        const auto materialist =
-          featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-        const auto positional = network[bucket].propagate(transformedFeatures);
+        const auto materialist = featureTransformer.transform(pos, accumulatorStack, cache,
+                                                              transformedFeatures, bucket, nullptr);
+        const auto positional  = network[bucket].propagate(transformedFeatures, nullptr);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);
         t.positional[bucket] = static_cast<Value>(positional / OutputScale);

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -99,7 +99,8 @@ struct NetworkArchitecture {
             && fc_2.write_parameters(stream);
     }
 
-    std::int32_t propagate(const TransformedFeatureType* transformedFeatures) const {
+    std::int32_t propagate(const TransformedFeatureType* transformedFeatures,
+                           const uint8_t*                nnz) const {
         struct alignas(CacheLineSize) Buffer {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
@@ -121,7 +122,7 @@ struct NetworkArchitecture {
         alignas(CacheLineSize) static thread_local Buffer buffer;
 #endif
 
-        fc_0.propagate(transformedFeatures, buffer.fc_0_out);
+        fc_0.propagate(transformedFeatures, nnz, buffer.fc_0_out);
         ac_sqr_0.propagate(buffer.fc_0_out, buffer.ac_sqr_0_out);
         ac_0.propagate(buffer.fc_0_out, buffer.ac_0_out);
         std::memcpy(buffer.ac_sqr_0_out + FC_0_OUTPUTS, buffer.ac_0_out,

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -237,7 +237,8 @@ class FeatureTransformer {
                            AccumulatorStack&                         accumulatorStack,
                            AccumulatorCaches::Cache<HalfDimensions>& cache,
                            OutputType*                               output,
-                           int                                       bucket) const {
+                           int                                       bucket,
+                           uint8_t*                                  nnz = nullptr) const {
 
         using namespace SIMD;
         accumulatorStack.evaluate(pos, *this, cache);
@@ -280,7 +281,8 @@ class FeatureTransformer {
             const vec_t* in0 = reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][0]));
             const vec_t* in1 =
               reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][HalfDimensions / 2]));
-            vec_t* out = reinterpret_cast<vec_t*>(output + offset);
+            vec_t*   out     = reinterpret_cast<vec_t*>(output + offset);
+            uint8_t* nnz_out = nnz + offset / 32;
 
             // Per the NNUE architecture, here we want to multiply pairs of
             // clipped elements and divide the product by 128. To do this,
@@ -365,6 +367,15 @@ class FeatureTransformer {
                     const vec_t pb = vec_mulhi_16(sum0b, sum1b);
 
                     out[j] = vec_packus_16(pa, pb);
+    #if defined(USE_AVX512)
+                    {
+                        uint16_t mask = _mm512_cmpgt_epi32_mask(out[j], _mm512_setzero_si512());
+                        std::memcpy(nnz_out + j * 2, &mask, sizeof(mask));
+                    }
+    #else
+                    nnz_out[j] = _mm256_movemask_ps(
+                      _mm256_castsi256_ps(_mm256_cmpgt_epi32(out[j], _mm256_setzero_si256())));
+    #endif
                 }
             }
             else
@@ -382,6 +393,15 @@ class FeatureTransformer {
                     const vec_t pb = vec_mulhi_16(sum0b, sum1b);
 
                     out[j] = vec_packus_16(pa, pb);
+    #if defined(USE_AVX512)
+                    {
+                        uint16_t mask = _mm512_cmpgt_epi32_mask(out[j], _mm512_setzero_si512());
+                        std::memcpy(nnz_out + j * 2, &mask, sizeof(mask));
+                    }
+    #else
+                    nnz_out[j] = _mm256_movemask_ps(
+                      _mm256_castsi256_ps(_mm256_cmpgt_epi32(out[j], _mm256_setzero_si256())));
+    #endif
                 }
             }
 


### PR DESCRIPTION
NNZ bitmask from ClippedReLU with sentinel bit technique. For
InputDimensions==128 (32 valid NNZ bits in uint64_t), sets bit 32
as sentinel and uses for(;;) with forward break. Converts
data-dependent while(bits) exit into a predictable always-not-taken
branch. Else path uses popcount counted loop (no sentinel possible
for full 64-bit words). On AVX-512 ICL: +0.3% NPS vs master
(speedtest 4, median of 5 runs, Dell Xeon w5 2445).

Bench: 3164843