### PR TITLE
Add read-only ss-6 to contcorr without write changes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -87,6 +87,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+                    + (*(ss - 6)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;


### PR DESCRIPTION
Add ss-6 to contcorr read path without any write changes. The ss-6 entry
reads cross-context data populated by ss-2 and ss-4 writes from other nodes.
No coefficient tuning, no architecture change, no write modification.

Bench: 3347951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Refined search evaluation to incorporate additional correction factors for improved position assessment accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->