### PR TITLE
Readweight contcorr with 3:2 read ratio for ss-2:ss-4

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,10 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+constexpr int CONTCORR_DEFAULT = 6;
+
+constexpr std::array<Search::ContcorrWeight, 2> contcorr = {{{2, 9622}, {4, 6342}}};
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -84,12 +88,22 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv  = 0;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    if (m.is_ok())
+    {
+        const Square sq = m.to_sq();
+        const Piece  pc = pos.piece_on(sq);
+        for (const auto& [i, weight] : contcorr)
+            cntcv += weight * (*(ss - i)->continuationCorrectionHistory)[pc][sq];
+    }
+    else
+    {
+        for (const auto& [i, weight] : contcorr)
+            cntcv += weight * CONTCORR_DEFAULT;
+    }
+
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -113,14 +127,11 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    const int    b  = bonus * int(m.is_ok());
+    const Square to = m.to_sq_unchecked();
+    const Piece  pc = pos.piece_on(to);
+    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << b;
+    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << b;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -611,7 +622,7 @@ void Search::Worker::clear() {
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
-            h.fill(6);
+            h.fill(CONTCORR_DEFAULT);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -374,6 +374,10 @@ struct ConthistBonus {
     int weight;
 };
 
+struct ContcorrWeight {
+    int index;
+    int weight;
+};
 
 }  // namespace Search
 


### PR DESCRIPTION
Per-ply read weights with 3:2 ratio (ss-2=9622, ss-4=6342), total 15964
matching master at saturation. Uniform linear writes to ss-2 and ss-4.
Uses CONTCORR_DEFAULT for fill and fallback consistency.

Bench: 3030534