### PR TITLE
Extra NMP reduction when correction history is large positive

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,10 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Scale factor: correction_value() returns centipawns * CORRECTION_VALUE_SCALE.
+// Used in to_corrected_static_eval (divide) and threshold comparisons (multiply).
+constexpr int CORRECTION_VALUE_SCALE = 131072;
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -95,7 +99,8 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
 // Add correctionHistory value to raw staticEval and guarantee evaluation
 // does not hit the tablebase range.
 Value to_corrected_static_eval(const Value v, const int cv) {
-    return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    return std::clamp(v + cv / CORRECTION_VALUE_SCALE, VALUE_TB_LOSS_IN_MAX_PLY + 1,
+                      VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 void update_correction_history(const Position& pos,
@@ -915,8 +920,12 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
+        // Null move dynamic reduction based on depth and large positive correction.
         Depth R = 7 + depth / 3;
+
+        // +192cp threshold: NNUE underestimates position, prune more aggressively.
+        R += correctionValue > 192 * CORRECTION_VALUE_SCALE;
+
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Summary

- Add CORRECTION_VALUE_SCALE = 131072 named constant (replaces bare literal in to_corrected_static_eval and in the NMP threshold).
- 131072 is the divisor that converts correctionValue units to centipawns; one centipawn = 131072 in correctionValue.
- Increase null move reduction R by 1 when correctionValue > 192 * CORRECTION_VALUE_SCALE (exactly +192cp of NNUE underestimation).
- When NNUE underestimates the position by +192cp and eval >= beta, NMP can prune more aggressively with higher confidence.

The threshold 192cp is roughly 40% of the achievable maximum (~483cp). The sign of correctionValue is informative: positive means the NNUE underestimates the side to move. This fires only in positions with significant underestimation.

Bench: 2972094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search evaluation correction scaling and adjusted null-move pruning to be more conservative when evaluations indicate a strong positive correction, yielding more accurate move selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->