### PR TITLE
Shared contcorr with sqrt(T) coefficient scaling

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -220,12 +220,19 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // on a given NUMA node. The passed size must be a power of two to make
 // the indexing more efficient.
 struct SharedHistories {
-    SharedHistories(size_t threadCount) :
+    SharedHistories(size_t threadCount, size_t actualThreads = 0) :
         correctionHistory(threadCount),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        // Coefficient scaling by floor(sqrt(actualThreads))
+        size_t t     = actualThreads > 0 ? actualThreads : threadCount;
+        int    sqrtT = 1;
+        while (size_t(sqrtT + 1) * size_t(sqrtT + 1) <= t)
+            sqrtT++;
+        contcorWriteS2 = std::max(1, 8064 / sqrtT);
+        contcorWriteS4 = std::max(1, 4032 / sqrtT);
     }
 
     size_t get_size() const { return sizeMinus1 + 1; }
@@ -263,6 +270,26 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    // Shared continuationCorrectionHistory with atomic entries.
+    // Cache-line aligned per outer (piece,sq) table to prevent false sharing at boundaries.
+    using AtomicPieceToCorrHist =
+      AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
+    struct alignas(64) AlignedPieceToCorrHist: AtomicPieceToCorrHist {};
+
+    MultiArray<AlignedPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        constexpr size_t total = PIECE_NB * SQUARE_NB;
+        size_t           start = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(6);
+    }
+
+    int contcorWriteS2;
+    int contcorWriteS4;
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -117,8 +117,8 @@ void update_correction_history(const Position& pos,
     const int    mask   = int(m.is_ok());
     const Square to     = m.to_sq_unchecked();
     const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
+    const int    bonus2 = (bonus * shared.contcorWriteS2 / 8192) * mask;
+    const int    bonus4 = (bonus * shared.contcorWriteS4 / 8192) * mask;
     (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
     (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
@@ -282,8 +282,9 @@ void Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->continuationCorrectionHistory =
+          &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->staticEval = VALUE_NONE;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
@@ -579,7 +580,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -587,7 +588,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -609,9 +610,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    sharedHistory.clear_contcorr_range(numaThreadIdx, numaTotal);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -62,21 +62,21 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                                    pv;
+    PieceToHistory*                          continuationHistory;
+    SharedHistories::AlignedPieceToCorrHist* continuationCorrectionHistory;
+    int                                      ply;
+    Move                                     currentMove;
+    Move                                     excludedMove;
+    Value                                    staticEval;
+    int                                      statScore;
+    int                                      moveCount;
+    bool                                     inCheck;
+    bool                                     ttPv;
+    bool                                     ttHit;
+    bool                                     followPV;
+    int                                      cutoffCnt;
+    int                                      reduction;
 };
 
 
@@ -291,9 +291,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -200,7 +200,7 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
             NumaIndex numaIndex = pair.first;
             uint64_t  count     = pair.second;
             auto      f         = [&]() {
-                sharedState.sharedHistories.try_emplace(numaIndex, next_power_of_two(count));
+                sharedState.sharedHistories.try_emplace(numaIndex, next_power_of_two(count), count);
             };
             if (doBindThreads)
                 numaConfig.execute_on_numa_node(numaIndex, f);


### PR DESCRIPTION
Share continuationCorrectionHistory across threads with write coefficient
scaling by floor(sqrt(T)) and cache-line aligned inner arrays.

Instead of scaling D (like halfshift/tscale-skip), scale the write bonus
before passing to the standard << operator, keeping D=1024 unchanged.

Write coefficients at 1 thread match master (126/128 and 63/128). For T
threads, coefficients are divided by floor(sqrt(T)) using integer-only
arithmetic.

Instrumentation showed average writers per occupied entry scales as sqrt(T):
d20: 1.00 (1T), 1.43 (2T), 1.97 (4T), 2.82 (8T), 4.02 (16T).

SMP-only change. No effect at 1 thread.

Bench: 3164843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Continuation-correction histories consolidated into shared, cache-aligned storage to reduce per-thread duplication.
  * Initialization and per-NUMA partitioned clearing updated for scalable, concurrent use.

* **Performance / Tuning**
  * History write scaling now adapts to actual thread counts, reducing contention and adjusting correction magnitudes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->