### PR TITLE
Symmetric depth-scaled NMP reduction by correction magnitude

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,8 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+constexpr int CORRECTION_VALUE_SCALE = 131072;
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -95,7 +97,8 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
 // Add correctionHistory value to raw staticEval and guarantee evaluation
 // does not hit the tablebase range.
 Value to_corrected_static_eval(const Value v, const int cv) {
-    return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    return std::clamp(v + cv / CORRECTION_VALUE_SCALE, VALUE_TB_LOSS_IN_MAX_PLY + 1,
+                      VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 void update_correction_history(const Position& pos,
@@ -915,8 +918,18 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
+        // Null move dynamic reduction based on depth and correction magnitude
         Depth R = 7 + depth / 3;
+
+        // Prune more if NNUE underestimates, less if it overestimates
+        constexpr int centipawns[] = {192, 256, 288};
+        const int     cvAbs        = std::abs(correctionValue);
+        Depth         rAdj         = 0;
+        for (int threshold : centipawns)
+            rAdj += (cvAbs > threshold * CORRECTION_VALUE_SCALE);
+        rAdj = (rAdj * depth) >> 4;
+        R += correctionValue < 0 ? -rAdj : rAdj;
+
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
## Summary
- Adjust NMP reduction based on correction value magnitude: deeper search when NNUE underestimates, shallower when it overestimates
- Three graduated thresholds at 192, 256, 288 centipawns with symmetric positive and negative arms
- Uses abs+sign pattern for efficient codegen: 3 comparisons on abs value, sar for /16, no additional idiv

## Test plan
- [ ] Verify bench matches 2722732
- [ ] Cutechess SPRT on hw2
- [ ] Assembly inspection confirms loop unrolling and sar for /16

Bench: 2722732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined search pruning: null-move verification now adapts to evaluation magnitude for more accurate reduction decisions, improving move selection quality.
  * More consistent evaluation handling to reduce edge-case variability in analysis and produce steadier static evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->