### PR TITLE
Unified symmetric NMP reduction with gradual depth scaling

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,6 +76,8 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+constexpr int CORRECTION_VALUE_SCALE = 131072;
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -95,7 +97,8 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
 // Add correctionHistory value to raw staticEval and guarantee evaluation
 // does not hit the tablebase range.
 Value to_corrected_static_eval(const Value v, const int cv) {
-    return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    return std::clamp(v + cv / CORRECTION_VALUE_SCALE, VALUE_TB_LOSS_IN_MAX_PLY + 1,
+                      VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 void update_correction_history(const Position& pos,
@@ -915,8 +918,17 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and correction magnitude.
+        // Prune more if NNUE underestimates, less if it overestimates.
+        constexpr unsigned centipawns[] = {192, 256, 288};
+        const unsigned     cvAbs        = std::abs(correctionValue);
+        unsigned           stepCount    = 0;
+        for (unsigned threshold : centipawns)
+            stepCount += (cvAbs > threshold * CORRECTION_VALUE_SCALE);
+        unsigned adj = correctionValue < 0 ? 6 - stepCount : 6 + stepCount;
+
+        Depth R = 7 + adj * depth / 16;
+
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);
@@ -1911,7 +1923,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 73 * (i < 2);
+            historyEntry << (bonus * weight * multiplier / CORRECTION_VALUE_SCALE) + 73 * (i < 2);
         }
     }
 }


### PR DESCRIPTION
## Summary

Symmetric depth-scaled null move reduction by correction magnitude using three
graduated thresholds at 192, 256, 288 centipawns. Increases R when NNUE
underestimates (prune more), decreases R when NNUE overestimates (prune less).

Uses a unified formula R = 7 + adj * depth / 16 where adj is 6 + signed
step count (range 3 to 9). This replaces the separated R = 7 + depth/3 + rAdj*depth/16.
The unified formula eliminates one idiv (depth/3) and produces gradual R increments
instead of double-jumps that occurred when both depth/3 and rAdj*depth/16 stepped
up at the same depth.

The / 16 on unsigned operands compiles to shr esi,0x4 (1-cycle shift), identical
codegen to the previous >> 4 expression.

Introduces CORRECTION_VALUE_SCALE named constant replacing all hardcoded 131072
values in search.cpp.

## Bench

2755171