### PR TITLE
Per-depth null move reduction for depths 18-26

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -913,7 +913,8 @@ Value Search::Worker::search(
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        constexpr int8_t nmp_r[] = {14, 14, 14, 13, 14, 15, 12, 14, 13};
+        const Depth R = (depth >= 18 && depth <= 26) ? nmp_r[depth - 18] : 7 + depth / 3;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Per-depth null move reduction lookup table for depths 18-26.

Values from SPSA tuning (nmp-perdepth-spsa-v2, 65% of 200K
iterations at LTC 80+0.8, 260K games). Depths outside 18-26
keep the master formula 7 + depth / 3.

R values: {14, 14, 14, 13, 14, 15, 12, 14, 13} for depths 18-26.

Bench: 3395207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the search algorithm's dynamic reduction mechanism to improve analysis efficiency for deeper search depths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->