### PR TITLE
Early return for no-op apply with burst prefetch

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -361,6 +361,101 @@ struct AccumulatorUpdateContext {
 
         const auto* threatWeights = &featureTransformer.threatWeights[0];
 
+        prefetch(fromAcc.data());
+
+        if (added.ssize() <= 3 && removed.ssize() <= 3)
+        {
+            auto pf = [&](IndexType idx) {
+                prefetch(&threatWeights[Dimensions * std::size_t(idx)]);
+            };
+
+            switch (added.ssize() * 4 + removed.ssize())
+            {
+            case 0 :
+                toAcc     = fromAcc;
+                toPsqtAcc = fromPsqtAcc;
+                return;
+            case 1 :
+                pf(removed[0]);
+                break;
+            case 2 :
+                pf(removed[0]);
+                pf(removed[1]);
+                break;
+            case 3 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(removed[2]);
+                break;
+            case 4 :
+                pf(added[0]);
+                break;
+            case 5 :
+                pf(removed[0]);
+                pf(added[0]);
+                break;
+            case 6 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(added[0]);
+                break;
+            case 7 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(removed[2]);
+                pf(added[0]);
+                break;
+            case 8 :
+                pf(added[0]);
+                pf(added[1]);
+                break;
+            case 9 :
+                pf(removed[0]);
+                pf(added[0]);
+                pf(added[1]);
+                break;
+            case 10 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(added[0]);
+                pf(added[1]);
+                break;
+            case 11 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(removed[2]);
+                pf(added[0]);
+                pf(added[1]);
+                break;
+            case 12 :
+                pf(added[0]);
+                pf(added[1]);
+                pf(added[2]);
+                break;
+            case 13 :
+                pf(removed[0]);
+                pf(added[0]);
+                pf(added[1]);
+                pf(added[2]);
+                break;
+            case 14 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(added[0]);
+                pf(added[1]);
+                pf(added[2]);
+                break;
+            case 15 :
+                pf(removed[0]);
+                pf(removed[1]);
+                pf(removed[2]);
+                pf(added[0]);
+                pf(added[1]);
+                pf(added[2]);
+                break;
+            }
+        }
+
         for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
         {
             auto* fromTile = reinterpret_cast<const vec_t*>(&fromAcc[j * Tiling::TileHeight]);


### PR DESCRIPTION
Burst prefetch all threat weight columns upfront via 16-case switch.
Case 0 (both added and removed empty, 23% of calls) does a plain
accumulator copy and returns early, skipping both SIMD tile loops.

Bench: 2926703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized neural network inference performance through improved memory access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->