### PR TITLE
Prefetch PSQ weight columns inside append_changed_indices

### DIFF
--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -118,17 +118,33 @@ void HalfKAv2_hm::append_active_indices(Color perspective, const Position& pos, 
 
 // Get a list of indices for recently changed features
 
-void HalfKAv2_hm::append_changed_indices(
-  Color perspective, Square ksq, const DiffType& diff, IndexList& removed, IndexList& added) {
-    removed.push_back(make_index(perspective, diff.from, diff.pc, ksq));
+void HalfKAv2_hm::append_changed_indices(Color           perspective,
+                                         Square          ksq,
+                                         const DiffType& diff,
+                                         IndexList&      removed,
+                                         IndexList&      added,
+                                         const void*     prefetchBase,
+                                         IndexType       prefetchStride) {
+    assert(!prefetchBase || prefetchStride != 0);
+
+    auto emit = [&](Square s, Piece pc, IndexList& list) {
+        auto idx = make_index(perspective, s, pc, ksq);
+        if (prefetchBase)
+            prefetch(static_cast<const char*>(prefetchBase)
+                     + static_cast<std::ptrdiff_t>(idx) * prefetchStride);
+        list.push_back(idx);
+    };
+
+    emit(diff.from, diff.pc, removed);
+
     if (diff.to != SQ_NONE)
-        added.push_back(make_index(perspective, diff.to, diff.pc, ksq));
+        emit(diff.to, diff.pc, added);
 
     if (diff.remove_sq != SQ_NONE)
-        removed.push_back(make_index(perspective, diff.remove_sq, diff.remove_pc, ksq));
+        emit(diff.remove_sq, diff.remove_pc, removed);
 
     if (diff.add_sq != SQ_NONE)
-        added.push_back(make_index(perspective, diff.add_sq, diff.add_pc, ksq));
+        emit(diff.add_sq, diff.add_pc, added);
 }
 
 bool HalfKAv2_hm::requires_refresh(const DiffType& diff, Color perspective) {

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -127,8 +127,13 @@ class HalfKAv2_hm {
     static void append_active_indices(Color perspective, const Position& pos, IndexList& active);
 
     // Get a list of indices for recently changed features
-    static void append_changed_indices(
-      Color perspective, Square ksq, const DiffType& diff, IndexList& removed, IndexList& added);
+    static void append_changed_indices(Color           perspective,
+                                       Square          ksq,
+                                       const DiffType& diff,
+                                       IndexList&      removed,
+                                       IndexList&      added,
+                                       const void*     prefetchBase   = nullptr,
+                                       IndexType       prefetchStride = 0);
 
     // Returns whether the change stored in this DirtyPiece means
     // that a full accumulator refresh is required.

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -500,11 +500,15 @@ void double_inc_update(Color                                                   p
     assert(!target_state.acc<TransformedFeatureDimensions>().computed[perspective]);
 
     PSQFeatureSet::IndexList removed, added;
-    PSQFeatureSet::append_changed_indices(perspective, ksq, middle_state.diff, removed, added);
+    const auto*              pfBase = static_cast<const void*>(&featureTransformer.weights[0]);
+    auto pfStride = static_cast<IndexType>(TransformedFeatureDimensions * sizeof(WeightType));
+    PSQFeatureSet::append_changed_indices(perspective, ksq, middle_state.diff, removed, added,
+                                          pfBase, pfStride);
     // you can't capture a piece that was just involved in castling since the rook ends up
     // in a square that the king passed
     assert(added.size() < 2);
-    PSQFeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added);
+    PSQFeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added,
+                                          pfBase, pfStride);
 
     [[maybe_unused]] const int addedSize   = added.ssize();
     [[maybe_unused]] const int removedSize = removed.ssize();
@@ -599,10 +603,14 @@ void update_accumulator_incremental(
     }
     else
     {
+        const auto* pfBase = static_cast<const void*>(&featureTransformer.weights[0]);
+        auto pfStride = static_cast<IndexType>(TransformedFeatureDimensions * sizeof(WeightType));
         if constexpr (Forward)
-            FeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added);
+            FeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added,
+                                               pfBase, pfStride);
         else
-            FeatureSet::append_changed_indices(perspective, ksq, computed.diff, added, removed);
+            FeatureSet::append_changed_indices(perspective, ksq, computed.diff, added, removed,
+                                               pfBase, pfStride);
     }
 
     auto updateContext =


### PR DESCRIPTION
Bench: 2926703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved neural-network evaluation memory access to reduce stalls, yielding faster position analysis and move scoring.
  * Refined feature-update paths to better utilize transformed weight memory, improving overall engine responsiveness and evaluation throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->