### PR TITLE
NMP TC-adaptive R using maxRootDepth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -443,6 +443,9 @@ void Search::Worker::iterative_deepening() {
         {
             completedDepth = rootDepth;
 
+            if (rootDepth > maxRootDepth)
+                maxRootDepth = rootDepth;
+
             if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
                 lastBestMoveDepth = rootDepth;
 
@@ -615,6 +618,8 @@ void Search::Worker::clear() {
             for (auto& to : continuationHistory[inCheck][c])
                 for (auto& h : to)
                     h.fill(-523);
+
+    maxRootDepth = 0;
 
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2763 / 128.0 * std::log(i));
@@ -912,8 +917,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and TC-adaptive scaling
+        Depth R = 7 + depth / 3 + (maxRootDepth >= 16 && 2 * depth > maxRootDepth);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);

--- a/src/search.h
+++ b/src/search.h
@@ -341,6 +341,7 @@ class Worker {
     StateInfo rootState;
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
+    Depth     maxRootDepth;
     Value     rootDelta;
 
     std::vector<Move> lastIterationPV;


### PR DESCRIPTION
Introduces maxRootDepth per worker: tracks the maximum rootDepth completed
across all moves in the current game, reset on ucinewgame.

Uses it to make NMP reduction TC-adaptive:
R = 7 + depth/3 + (maxRootDepth >= 16 && 2 * depth > maxRootDepth)

This adds R+=1 when depth is in the upper half of the typical search depth
for the current time control. Activation: ~30% at STC, ~20% at LTC, ~3% at
VVLTC. The extra reduction fades at longer TC where verification search is
stronger.

Bench: 2926703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized null-move reduction strategy during iterative deepening search to provide more conservative pruning decisions when analyzing deeper positions under extended time controls, improving move evaluation accuracy and overall engine performance in tactical sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->