### PR TITLE
Shared contcorr with quadratic headroom dampening

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -263,6 +263,33 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    // Shared continuationCorrectionHistory with atomic entries.
+    using AtomicPieceToCorrHist =
+      AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
+    struct alignas(64) AlignedPieceToCorrHist: AtomicPieceToCorrHist {};
+
+    MultiArray<AlignedPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        constexpr size_t total = PIECE_NB * SQUARE_NB;
+        size_t           start = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(6);
+    }
+
+    // Quadratic dampening of contcorr writes.
+    static void contcorr_update(AtomicPieceToCorrHist& hist, Piece pc, Square to, int bonus) {
+        constexpr int D           = CORRECTION_HISTORY_LIMIT;
+        auto&         e           = hist[pc][to];
+        const int     v           = int(e);
+        const int     head        = D - std::abs(v);
+        const int     damp        = int(int64_t(bonus) * head * head / (int64_t(D) * D));
+        const int     dampedBonus = std::clamp(damp, -D, D);
+        e = std::int16_t(std::clamp(v + dampedBonus - v * std::abs(dampedBonus) / D, -D, D));
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,14 +113,15 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+    if (m.is_ok())
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(to);
+        const int    b2 = bonus * 126 / 128;
+        const int    b4 = bonus * 63 / 128;
+        SharedHistories::contcorr_update(*(ss - 2)->continuationCorrectionHistory, pc, to, b2);
+        SharedHistories::contcorr_update(*(ss - 4)->continuationCorrectionHistory, pc, to, b4);
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -284,8 +285,9 @@ void Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->continuationCorrectionHistory =
+          &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->staticEval = VALUE_NONE;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
@@ -576,7 +578,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -584,7 +586,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -606,9 +608,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    sharedHistory.clear_contcorr_range(numaThreadIdx, numaTotal);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -62,21 +62,21 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                                    pv;
+    PieceToHistory*                          continuationHistory;
+    SharedHistories::AlignedPieceToCorrHist* continuationCorrectionHistory;
+    int                                      ply;
+    Move                                     currentMove;
+    Move                                     excludedMove;
+    Value                                    staticEval;
+    int                                      statScore;
+    int                                      moveCount;
+    bool                                     inCheck;
+    bool                                     ttPv;
+    bool                                     ttHit;
+    bool                                     followPV;
+    int                                      cutoffCnt;
+    int                                      reduction;
 };
 
 
@@ -291,9 +291,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Bench: 3021866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Continuation-correction history centralized into a shared, NUMA-aware structure to remove per-thread duplication and have search stacks reference the shared history.
  * Reset of continuation-correction data now occurs per-NUMA partition.

* **Bug Fixes / Stability**
  * Continuation-correction updates are skipped for invalid moves, avoiding incorrect reads/writes and improving search stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->