### PR TITLE
Prefetch contcorr entries in make_move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -572,11 +572,15 @@ void Search::Worker::do_move(
 
     if (ss != nullptr)
     {
-        ss->currentMove = move;
-        ss->continuationHistory =
-          &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+        const Piece  pc = dirtyPiece.pc;
+        const Square to = move.to_sq();
+
+        ss->currentMove                   = move;
+        ss->continuationHistory           = &continuationHistory[ss->inCheck][capture][pc][to];
+        ss->continuationCorrectionHistory = &continuationCorrectionHistory[pc][to];
+
+        prefetch(&(*(ss - 1)->continuationCorrectionHistory)[pc][to]);
+        prefetch(&(*(ss - 3)->continuationCorrectionHistory)[pc][to]);
     }
 }
 


### PR DESCRIPTION
Bench: 2926703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal search performance through caching mechanisms and prefetching strategies to improve computational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->