### PR TITLE
Skip zero-bonus correction history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1495,7 +1495,9 @@ moves_loop:  // When in check, search starts here
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
                      -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
-        update_correction_history(pos, ss, *this, 1069 * bonus / 1024);
+        bonus = 1069 * bonus / 1024;
+        if (bonus != 0)
+            update_correction_history(pos, ss, *this, bonus);
     }
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
Bench: 2926703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the search algorithm by refining when correction history updates are performed, skipping operations when adjustments equal zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->