### PR TITLE
Shared contcorr qdamp D=16384 clamp48

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -38,7 +38,7 @@ namespace Stockfish {
 constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
 constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
-constexpr int CORRECTION_HISTORY_LIMIT = 1024;
+constexpr int CORRECTION_HISTORY_LIMIT = 16384;  // has to be a power of 2
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
@@ -47,12 +47,17 @@ static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
 
+enum class CorrUpdate {
+    DEFAULT,
+    QUADRATIC
+};
+
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
 // the entry. The first template parameter T is the base type of the array,
 // and the second template parameter D limits the range of updates in [-D, D]
 // when we update values with the << operator
-template<typename T, int D, bool Atomic = false>
+template<typename T, int D, bool Atomic = false, CorrUpdate Mode = CorrUpdate::DEFAULT>
 struct StatsEntry {
     static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
 
@@ -75,10 +80,15 @@ struct StatsEntry {
     }
 
     void operator<<(int bonus) {
-        // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if constexpr (Mode == CorrUpdate::QUADRATIC)
+        {
+            const int headroom = D - std::abs(int(val));
+            const int damp = int(int64_t(clampedBonus) * headroom * headroom / (int64_t(D) * D));
+            clampedBonus   = std::clamp(damp, -D, D);
+        }
+        *this = val + clampedBonus - val * std::abs(clampedBonus) / D;
 
         assert(std::abs(T(*this)) <= D);
     }
@@ -94,6 +104,12 @@ using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
 template<typename T, int D, std::size_t... Sizes>
 using AtomicStats = MultiArray<StatsEntry<T, D, true>, Sizes...>;
+
+template<typename T, int D, std::size_t... Sizes>
+using QuadraticStats = MultiArray<StatsEntry<T, D, false, CorrUpdate::QUADRATIC>, Sizes...>;
+
+template<typename T, int D, std::size_t... Sizes>
+using QuadraticAtomicStats = MultiArray<StatsEntry<T, D, true, CorrUpdate::QUADRATIC>, Sizes...>;
 
 // DynStats is a dynamically sized array of Stats, used for thread-shared histories
 // which should scale with the total number of threads. The SizeMultiplier gives
@@ -167,10 +183,10 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    StatsEntry<T, D, true, CorrUpdate::QUADRATIC> pawn;
+    StatsEntry<T, D, true, CorrUpdate::QUADRATIC> minor;
+    StatsEntry<T, D, true, CorrUpdate::QUADRATIC> nonPawnWhite;
+    StatsEntry<T, D, true, CorrUpdate::QUADRATIC> nonPawnBlack;
 
     void operator=(T val) {
         pawn         = val;
@@ -184,13 +200,13 @@ namespace Detail {
 
 template<CorrHistType>
 struct CorrHistTypedef {
-    using type =
-      DynStats<Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB>, CORRHIST_BASE_SIZE>;
+    using type = DynStats<QuadraticStats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB>,
+                          CORRHIST_BASE_SIZE>;
 };
 
 template<>
 struct CorrHistTypedef<PieceTo> {
-    using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+    using type = QuadraticStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
 };
 
 template<>
@@ -200,8 +216,9 @@ struct CorrHistTypedef<Continuation> {
 
 template<>
 struct CorrHistTypedef<NonPawn> {
-    using type = DynStats<Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, COLOR_NB>,
-                          CORRHIST_BASE_SIZE>;
+    using type =
+      DynStats<QuadraticStats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, COLOR_NB>,
+               CORRHIST_BASE_SIZE>;
 };
 
 }
@@ -263,6 +280,24 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    // Shared continuationCorrectionHistory with atomic entries
+    using AtomicPieceToCorrHist =
+      QuadraticAtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, PIECE_NB, SQUARE_NB>;
+
+    struct alignas(64) AlignedPieceToCorrHist: AtomicPieceToCorrHist {};
+
+    MultiArray<AlignedPieceToCorrHist, PIECE_NB, SQUARE_NB> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        assert(numaTotal > 0 && threadIdx < numaTotal);
+        constexpr size_t total                 = PIECE_NB * SQUARE_NB;
+        constexpr int    correctionHistoryFill = 96;  // can be SPSA-tuned
+        size_t           start                 = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(correctionHistoryFill);
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -89,7 +89,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+                  : 128;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -97,7 +97,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
 // Add correctionHistory value to raw staticEval and guarantee evaluation
 // does not hit the tablebase range.
 Value to_corrected_static_eval(const Value v, const int cv) {
-    return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    return std::clamp(v + cv / 2097152, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 void update_correction_history(const Position& pos,
@@ -110,17 +110,17 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_entry(pos).at(us).pawn << bonus * 16;
+    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 8;
+    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 8;
+    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 8;
 
     if (m.is_ok())
     {
         const Square to = m.to_sq();
         const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 8;
+        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 8;
     }
 }
 
@@ -283,8 +283,9 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->continuationCorrectionHistory =
+          &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
+        (ss - i)->staticEval = VALUE_NONE;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
@@ -574,7 +575,7 @@ void Search::Worker::do_move(
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+          &sharedHistory.continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
     }
 }
 
@@ -582,7 +583,7 @@ void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss)
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->continuationCorrectionHistory = &sharedHistory.continuationCorrectionHistory[NO_PIECE][0];
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -604,9 +605,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    sharedHistory.clear_contcorr_range(numaThreadIdx, numaTotal);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})
@@ -896,7 +895,7 @@ Value Search::Worker::search(
 
             return futilityMult * d
                  - (2686 * improving + 362 * opponentWorsening) * futilityMult / 1024  //
-                 + std::abs(correctionValue) / 180600;
+                 + std::abs(correctionValue) / 2889600;
         };
 
         if (!ss->ttPv && depth < 15 && eval - futility_margin(depth) >= beta && eval >= beta
@@ -1154,7 +1153,7 @@ moves_loop:  // When in check, search starts here
 
             if (value < singularBeta)
             {
-                int corrValAdj   = std::abs(correctionValue) / 210590;
+                int corrValAdj   = std::abs(correctionValue) / 3369440;
                 int doubleMargin = -4 + 212 * PvNode - 182 * !ttCapture - corrValAdj
                                  - 906 * ttMoveHistory / 116517 - (ss->ply > rootDepth) * 44;
                 int tripleMargin = 73 + 320 * PvNode - 218 * !ttCapture + 92 * ss->ttPv - corrValAdj
@@ -1209,7 +1208,7 @@ moves_loop:  // When in check, search starts here
 
         r += 691;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 65;
-        r -= std::abs(correctionValue) / 25600;
+        r -= std::abs(correctionValue) / 409600;
 
         // Increase reduction for cut nodes
         if (cutNode)
@@ -1490,9 +1489,10 @@ moves_loop:  // When in check, search starts here
     if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
         && (bestValue > ss->staticEval) == bool(bestMove))
     {
-        auto bonus =
+        constexpr int bonusClamp = CORRECTION_HISTORY_LIMIT / 48;
+        auto          bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
-                     -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                     -bonusClamp, bonusClamp);
         update_correction_history(pos, ss, *this, 1069 * bonus / 1024);
     }
 

--- a/src/search.h
+++ b/src/search.h
@@ -62,21 +62,21 @@ namespace Search {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    Move*                       pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    Move*                                    pv;
+    PieceToHistory*                          continuationHistory;
+    SharedHistories::AlignedPieceToCorrHist* continuationCorrectionHistory;
+    int                                      ply;
+    Move                                     currentMove;
+    Move                                     excludedMove;
+    Value                                    staticEval;
+    int                                      statScore;
+    int                                      moveCount;
+    bool                                     inCheck;
+    bool                                     ttPv;
+    bool                                     ttHit;
+    bool                                     followPV;
+    int                                      cutoffCnt;
+    int                                      reduction;
 };
 
 
@@ -291,12 +291,10 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
-
-    TTMoveHistory    ttMoveHistory;
-    SharedHistories& sharedHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
+    TTMoveHistory         ttMoveHistory;
+    SharedHistories&      sharedHistory;
 
    private:
     bool iterative_deepening();


### PR DESCRIPTION
Same as shared-contcorr-qdamp-d16384 but raises the update_all_stats call-site
bonus clamp from CORRECTION_HISTORY_LIMIT / 64 (256) to
CORRECTION_HISTORY_LIMIT / 48 (341), stored as a constexpr named constant.

Bench: 2746101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Optimization**
  * Enhanced evaluation correction mechanism with increased capacity and improved damping strategy.
  * Refined scaling factors for positional adjustments and search margins to better calibrate move selection.
  * Reorganized memory allocation for shared evaluation history to improve cache efficiency and parallel performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->