### PR TITLE
Simplify correction write weights, adjust read coefficients

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -91,7 +91,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return 12153 * pcv + 10304 * micv + 18050 * (wnpcv + bnpcv) + 7857 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -107,20 +107,19 @@ void update_correction_history(const Position& pos,
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
-    constexpr int nonPawnWeight = 187;
-    auto&         shared        = workerThread.sharedHistory;
+    auto& shared = workerThread.sharedHistory;
 
     shared.pawn_correction_entry(pos).at(us).pawn << bonus;
-    shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.minor_piece_correction_entry(pos).at(us).minor << bonus;
+    shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus;
+    shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus;
 
     if (m.is_ok())
     {
         const Square to = m.to_sq();
         const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus;
+        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus / 2;
     }
 }
 


### PR DESCRIPTION
Remove per-entry bonus weight multiplies from update_correction_history.
All entries receive raw bonus except ss-4 contcorr (bonus/2). Read
coefficients adjusted to preserve effective weights.

Bench: 3204371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal evaluation calculation methods to improve position assessment accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->