### PR TITLE
Relax LMR by one ply when depth exceeds median root depth by 3

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -443,6 +443,9 @@ bool Search::Worker::iterative_deepening() {
         {
             completedDepth = rootDepth;
 
+            if (rootDepth > maxRootDepth)
+                maxRootDepth = rootDepth;
+
             if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
                 lastBestMoveDepth = rootDepth;
 
@@ -544,6 +547,15 @@ bool Search::Worker::iterative_deepening() {
         iterIdx                        = (iterIdx + 1) & 3;
     }
 
+    completedDepthHistory[completedMoveCount & 63] = completedDepth;
+    completedMoveCount++;
+
+    int   count = std::min(completedMoveCount, 64);
+    Depth sorted[64];
+    std::copy_n(completedDepthHistory, count, sorted);
+    std::sort(sorted, sorted + count);
+    medianRootDepth = sorted[count / 2];
+
     if (!mainThread)
         return false;
 
@@ -620,6 +632,11 @@ void Search::Worker::clear() {
 
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2763 / 128.0 * std::log(i));
+
+    maxRootDepth       = 0;
+    completedMoveCount = 0;
+    medianRootDepth    = 0;
+    std::fill(std::begin(completedDepthHistory), std::end(completedDepthHistory), Depth(0));
 
     refreshTable.clear(networks[numaAccessToken]);
 }
@@ -1211,6 +1228,7 @@ moves_loop:  // When in check, search starts here
                + (ttData.depth >= depth) * (935 + cutNode * 959);
 
         r += 691;  // Base reduction offset to compensate for other tweaks
+        r -= 1024 * (depth > medianRootDepth + 3 && completedMoveCount > 20);
         r -= moveCount * 65;
         r -= std::abs(correctionValue) / 25600;
 

--- a/src/search.h
+++ b/src/search.h
@@ -381,6 +381,10 @@ class Worker {
     StateInfo rootState;
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
+    Depth     maxRootDepth;
+    Depth     completedDepthHistory[64];
+    int       completedMoveCount;
+    Depth     medianRootDepth;
     Value     rootDelta;
 
     PVMoves lastIterationPV;


### PR DESCRIPTION
Bench: 3043897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search now tracks observed search depths and maintains a short history to make adaptive move-reduction decisions.
  * State is reset when a new search starts, ensuring fresh thresholds per search.
  * Move-pruning becomes more conservative until sufficient history is gathered, leading to more stable and consistent search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->