### PR TITLE
Lower singular beta when depth exceeds median root depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -443,6 +443,9 @@ bool Search::Worker::iterative_deepening() {
         {
             completedDepth = rootDepth;
 
+            if (rootDepth > maxRootDepth)
+                maxRootDepth = rootDepth;
+
             if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
                 lastBestMoveDepth = rootDepth;
 
@@ -544,6 +547,15 @@ bool Search::Worker::iterative_deepening() {
         iterIdx                        = (iterIdx + 1) & 3;
     }
 
+    completedDepthHistory[completedMoveCount & 63] = completedDepth;
+    completedMoveCount++;
+
+    int   count = std::min(completedMoveCount, 64);
+    Depth sorted[64];
+    std::copy_n(completedDepthHistory, count, sorted);
+    std::sort(sorted, sorted + count);
+    medianRootDepth = sorted[count / 2];
+
     if (!mainThread)
         return false;
 
@@ -620,6 +632,11 @@ void Search::Worker::clear() {
 
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2763 / 128.0 * std::log(i));
+
+    maxRootDepth       = 0;
+    completedMoveCount = 0;
+    medianRootDepth    = 0;
+    std::fill(std::begin(completedDepthHistory), std::end(completedDepthHistory), Depth(0));
 
     refreshTable.clear(networks[numaAccessToken]);
 }
@@ -1148,7 +1165,8 @@ moves_loop:  // When in check, search starts here
             && is_valid(ttData.value) && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
             && ttData.depth >= depth - 3 && !is_shuffling(move, ss, pos))
         {
-            Value singularBeta  = ttData.value - (60 + 66 * (ss->ttPv && !PvNode)) * depth / 55;
+            Value singularBeta = ttData.value - (60 + 66 * (ss->ttPv && !PvNode)) * depth / 55
+                               - 15 * (completedMoveCount > 20 && depth > medianRootDepth + 3);
             Depth singularDepth = newDepth / 2;
 
             ss->excludedMove = move;

--- a/src/search.h
+++ b/src/search.h
@@ -381,6 +381,10 @@ class Worker {
     StateInfo rootState;
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
+    Depth     maxRootDepth;
+    Depth     completedDepthHistory[64];
+    int       completedMoveCount;
+    Depth     medianRootDepth;
     Value     rootDelta;
 
     PVMoves lastIterationPV;


### PR DESCRIPTION
Lower singularBeta by 15 when the current search depth exceeds the per-worker
median root depth by 3 and at least 20 game moves have completed. This makes
singular extensions trigger more easily in easy positions where the search has
more depth budget than typical. Uses a 64-entry ring buffer for non-monotone
median computation.

Bench: 2922733