### PR TITLE
Shared 4-ply hash continuation correction

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -40,12 +40,16 @@ constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+constexpr int JOINT_CORR_BASE_SIZE     = 16384;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((JOINT_CORR_BASE_SIZE & (JOINT_CORR_BASE_SIZE - 1)) == 0,
+              "JOINT_CORR_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -215,6 +219,9 @@ using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 
+using JointCorrectionHistory =
+  DynStats<AtomicStats<std::int16_t, CORRECTION_HISTORY_LIMIT, 1>, JOINT_CORR_BASE_SIZE>;
+
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads
 // on a given NUMA node. The passed size must be a power of two to make
@@ -222,10 +229,12 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
         correctionHistory(threadCount),
-        pawnHistory(threadCount) {
+        pawnHistory(threadCount),
+        jointCorrectionHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
-        sizeMinus1         = correctionHistory.get_size() - 1;
-        pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        sizeMinus1          = correctionHistory.get_size() - 1;
+        pawnHistSizeMinus1  = pawnHistory.get_size() - 1;
+        jointCorrSizeMinus1 = jointCorrectionHistory.get_size() - 1;
     }
 
     size_t get_size() const { return sizeMinus1 + 1; }
@@ -260,12 +269,19 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
+    auto& joint_correction_entry(size_t hash) {
+        return jointCorrectionHistory[hash & jointCorrSizeMinus1][0];
+    }
+    const auto& joint_correction_entry(size_t hash) const {
+        return jointCorrectionHistory[hash & jointCorrSizeMinus1][0];
+    }
+
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
-
+    JointCorrectionHistory   jointCorrectionHistory;
 
    private:
-    size_t sizeMinus1, pawnHistSizeMinus1;
+    size_t sizeMinus1, pawnHistSizeMinus1, jointCorrSizeMinus1;
 };
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,20 +81,37 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// joint correction hash. Layout:
+//   bit   9    : color       (0 = white, 1 = black)
+//   bits  6..8 : piece type  (PAWN..KING; NO_PIECE_TYPE = 0 for sentinel)
+//   bits  0..5 : square      (A1..H8)
+unsigned contcorr_index(Piece pc, Square sq) { return unsigned(pc) * 64 + unsigned(sq); }
+
+uint32_t contcorr_hash_4ply(unsigned idx1, unsigned idx2, unsigned idx3, unsigned idx4) {
+    // Three-prime Horner hash. Primes chosen by FFT enumeration over the
+    // Piece-based index domain ({0} U {pc*64+sq}, 769 values in [0,1024))
+    // to minimize chi2/mean across modulus N = T * 16384.
+    // Don't SPSA-tune: hash multipliers have no smooth optimum.
+    constexpr uint64_t primeHashMult2Ply = 383;
+    constexpr uint64_t primeHashMult3Ply = 1009;
+    constexpr uint64_t primeHashMult4Ply = 1129;
+    return uint32_t(
+      (((uint64_t(idx1) * primeHashMult2Ply + idx2) * primeHashMult3Ply + idx3) * primeHashMult4Ply
+       + idx4)
+      & 0xFFFFFFFFu);
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    const int   jcv    = int(shared.joint_correction_entry(ss->contcorrHash));
 
-    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
+    return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 11973 * jcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -107,7 +124,6 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 187;
@@ -118,13 +134,7 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
-    {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
-    }
+    shared.joint_correction_entry(ss->contcorrHash) << bonus;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -285,9 +295,11 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->contcorrHash  = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrHash = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
         (ss + i)->ply = i;
@@ -577,16 +589,20 @@ void Search::Worker::do_move(
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+        ss->contcorrIndex = contcorr_index(pos.piece_on(move.to_sq()), move.to_sq());
+        (ss + 1)->contcorrHash =
+          contcorr_hash_4ply(ss->contcorrIndex, (ss - 1)->contcorrIndex, (ss - 2)->contcorrIndex,
+                             (ss - 3)->contcorrIndex);
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = contcorr_index(NO_PIECE, SQ_A1);
+    (ss + 1)->contcorrHash  = contcorr_hash_4ply(ss->contcorrIndex, (ss - 1)->contcorrIndex,
+                                                 (ss - 2)->contcorrIndex, (ss - 3)->contcorrIndex);
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -605,12 +621,9 @@ void Search::Worker::clear() {
     // Each thread is responsible for clearing their part of shared history
     sharedHistory.correctionHistory.clear_range(0, numaThreadIdx, numaTotal);
     sharedHistory.pawnHistory.clear_range(-1238, numaThreadIdx, numaTotal);
+    sharedHistory.jointCorrectionHistory.clear_range(0, numaThreadIdx, numaTotal);
 
     ttMoveHistory = 0;
-
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,22 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*        pv;
+    PieceToHistory* continuationHistory;
+    int             ply;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    int             statScore;
+    int             moveCount;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
+    int             cutoffCnt;
+    int             reduction;
+    unsigned        contcorrIndex;
+    uint32_t        contcorrHash;
 };
 
 
@@ -331,9 +332,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
## Summary

Extend the shared joint correction hash to four plies. A single NUMA-shared atomic DynStats table (JOINT_CORR_BASE_SIZE=16384) is indexed by a three-prime Horner hash over (ss-2, ss-3, ss-4, ss-5) ancestor move signatures. Replaces master's per-worker ss-2 and ss-4 pair-reads.

## Index and hash

Each stack frame carries `contcorrIndex = unsigned(Piece) * 64 + unsigned(Square)`, layout bit 9 color, bits 6-8 type, bits 0-5 square (10 bits, 769 reachable values including the NO_PIECE sentinel). Piece read post-move via `pos.piece_on(move.to_sq())` preserves promotion type.

Joint hash: `H = (((idx1 * P1 + idx2) * P2 + idx3) * P3 + idx4) mod N` with `P1 = 383`, `P2 = 1009`, `P3 = 1129`. Primes re-enumerated by full FFT convolution over the 769-value Piece domain; each is top-1 for its ply-count given the preceding fixes. See research/contcorr-hash-multiplier-analysis.md for enumeration tables.

Branch name "joint4-p1409" is carried over from an earlier enumeration against the 512-value domain (where P3=1409 was top-1). Under the Piece-based rework the committed P3 constant is 1129; the branch name is kept to avoid churning the branch/PR pair.

## Read coefficient

Master sums two entries with coefficient 7982 and asymmetric write weights (1:2 ratio). Sum is ~1.5x a single full-bonus entry, so the joint read uses `7982 * 3/2 = 11973`. Write uses full bonus.

## Table scaling

Product of P1 * P2 * P3 far exceeds DynStats range for realistic threadCount, so standard DynStats scaling `N = threadCount * 16384` is used without a shard cap.

## Bench

2757825
