### PR TITLE
Tagged thread-local joint correction history 128K

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,29 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+// Tagged thread-local joint correction history.
+constexpr int      JOINT_CORR_BITS       = 17;
+constexpr size_t   JOINT_CORR_BASE_SIZE  = size_t(1) << JOINT_CORR_BITS;
+constexpr uint32_t JOINT_CORR_INDEX_MASK = uint32_t(JOINT_CORR_BASE_SIZE - 1);
+constexpr int      JOINT_CORR_TAG_BITS   = 20;
+constexpr uint32_t JOINT_CORR_TAG_MASK   = (uint32_t(1) << JOINT_CORR_TAG_BITS) - 1;
+constexpr int16_t  JOINT_CORR_INIT       = 6;
+constexpr int16_t  JOINT_CORR_NOK        = 8;
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((JOINT_CORR_BASE_SIZE & (JOINT_CORR_BASE_SIZE - 1)) == 0,
+              "JOINT_CORR_BASE_SIZE has to be a power of 2");
+
+// Guard the packed slot's signed value field against a future SPSA tune
+// that raises CORRECTION_HISTORY_LIMIT past the 12-bit signed range.
+static_assert(CORRECTION_HISTORY_LIMIT <= (1 << 11) - 1,
+              "JointCorrSlot::value is int : 12 signed ([-2048, 2047]); "
+              "widen the field or lower CORRECTION_HISTORY_LIMIT");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -214,6 +232,17 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+// Packed slot for the tagged thread-local joint correction history.
+// 12-bit signed value + 20-bit tag in a single 32-bit word. tag == 0
+// denotes an empty slot; tag generation reserves 0 by remapping to 1.
+struct alignas(4) JointCorrSlot {
+    std::int32_t  value: 12;
+    std::uint32_t tag: JOINT_CORR_TAG_BITS;
+};
+static_assert(sizeof(JointCorrSlot) == 4, "JointCorrSlot must be 4 bytes");
+
+using JointCorrectionHistory = std::array<JointCorrSlot, JOINT_CORR_BASE_SIZE>;
 
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -81,18 +82,52 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// joint correction hash. NO_PIECE paired with SQ_A1 is the canonical
+// zero sentinel used before the root.
+unsigned contcorr_index(Piece pc, Square sq) { return unsigned(pc) * 64 + unsigned(sq); }
+
+// 64-bit mixer producing both a table index and a verification tag from
+// two 10-bit contcorrIndex inputs. Two rounds of multiply-xor-shift using
+// SplitMix64-derived odd multipliers; not the exact three-round SplitMix64
+// finalizer, but avalanches all 64 output bits so the tag is statistically
+// independent of the index.
+uint64_t contcorr_mix(uint32_t a, uint32_t b) {
+    uint64_t k = (uint64_t(a) << 10) | b;
+    k *= 0x9E3779B97F4A7C15ULL;
+    k ^= k >> 32;
+    k *= 0xBF58476D1CE4E5B9ULL;
+    k ^= k >> 27;
+    return k;
+}
+
+uint32_t contcorr_idx_from(uint64_t h) { return uint32_t(h) & JOINT_CORR_INDEX_MASK; }
+
+// Reserve tag == 0 as the empty-slot sentinel so a freshly cleared
+// (all-zeros) table behaves as if every access misses and returns INIT.
+uint32_t contcorr_tag_from(uint64_t h) {
+    uint32_t t = uint32_t(h >> JOINT_CORR_BITS) & JOINT_CORR_TAG_MASK;
+    return t == 0 ? 1u : t;
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if ((ss - 1)->currentMove.is_ok())
+    {
+        const auto& sA = w.jointCorrectionHistory[ss->contcorrIdxA];
+        const auto& sB = w.jointCorrectionHistory[ss->contcorrIdxB];
+        int         a  = sA.tag == ss->contcorrTagA ? int(sA.value) : int(JOINT_CORR_INIT);
+        int         b  = sB.tag == ss->contcorrTagB ? int(sB.value) : int(JOINT_CORR_INIT);
+        cntcv          = a + b;
+    }
+    else
+        cntcv = JOINT_CORR_NOK;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,7 +142,6 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 187;
@@ -118,12 +152,16 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
+    if ((ss - 1)->currentMove.is_ok())
     {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        auto update = [](JointCorrSlot& s, uint32_t tag, int b) {
+            int v   = s.tag == tag ? int(s.value) : int(JOINT_CORR_INIT);
+            v       = v + b - v * std::abs(b) / CORRECTION_HISTORY_LIMIT;
+            s.tag   = tag;
+            s.value = v;
+        };
+        update(workerThread.jointCorrectionHistory[ss->contcorrIdxA], ss->contcorrTagA, bonus);
+        update(workerThread.jointCorrectionHistory[ss->contcorrIdxB], ss->contcorrTagB, bonus / 2);
     }
 }
 
@@ -285,9 +323,17 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->contcorrIdxA  = 0;
+        (ss - i)->contcorrTagA  = 0;
+        (ss - i)->contcorrIdxB  = 0;
+        (ss - i)->contcorrTagB  = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrIdxA = 0;
+    ss->contcorrTagA = 0;
+    ss->contcorrIdxB = 0;
+    ss->contcorrTagB = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
         (ss + i)->ply = i;
@@ -577,16 +623,32 @@ void Search::Worker::do_move(
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+
+        ss->contcorrIndex = contcorr_index(dirtyPiece.pc, move.to_sq());
+
+        // Seed child hashes: at the read site ss becomes (ss-1), our
+        // (ss-1) becomes (ss-2), and our (ss-3) becomes (ss-4).
+        const uint64_t hA      = contcorr_mix(ss->contcorrIndex, (ss - 1)->contcorrIndex);
+        const uint64_t hB      = contcorr_mix(ss->contcorrIndex, (ss - 3)->contcorrIndex);
+        (ss + 1)->contcorrIdxA = contcorr_idx_from(hA);
+        (ss + 1)->contcorrTagA = contcorr_tag_from(hA);
+        (ss + 1)->contcorrIdxB = contcorr_idx_from(hB);
+        (ss + 1)->contcorrTagB = contcorr_tag_from(hB);
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = contcorr_index(NO_PIECE, SQ_A1);
+
+    const uint64_t hA      = contcorr_mix(ss->contcorrIndex, (ss - 1)->contcorrIndex);
+    const uint64_t hB      = contcorr_mix(ss->contcorrIndex, (ss - 3)->contcorrIndex);
+    (ss + 1)->contcorrIdxA = contcorr_idx_from(hA);
+    (ss + 1)->contcorrTagA = contcorr_tag_from(hA);
+    (ss + 1)->contcorrIdxB = contcorr_idx_from(hB);
+    (ss + 1)->contcorrTagB = contcorr_tag_from(hB);
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -608,9 +670,10 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    // Zero-initialize: tag == 0 is the empty-slot sentinel; read path
+    // returns JOINT_CORR_INIT for any access that does not match.
+    std::memset(jointCorrectionHistory.data(), 0,
+                sizeof(JointCorrSlot) * jointCorrectionHistory.size());
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,25 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*        pv;
+    PieceToHistory* continuationHistory;
+    int             ply;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    int             statScore;
+    int             moveCount;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
+    int             cutoffCnt;
+    int             reduction;
+    unsigned        contcorrIndex;
+    uint32_t        contcorrIdxA;
+    uint32_t        contcorrTagA;
+    uint32_t        contcorrIdxB;
+    uint32_t        contcorrTagB;
 };
 
 
@@ -331,9 +335,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory  captureHistory;
+    ContinuationHistory    continuationHistory[2][2];
+    JointCorrectionHistory jointCorrectionHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Tagged thread-local joint correction history with 131072 slots per worker.
Each 32-bit slot packs a 12-bit signed value with a 20-bit tag. Read checks
the tag and returns JOINT_CORR_INIT on mismatch; write evicts on mismatch,
updates in place on match. Replaces the 4D continuationCorrectionHistory
(2 MiB per worker) with 512 KiB per worker.

Bench: 3756868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the engine’s move correction history into a compact, joint hash-backed layout. This consolidates previously separate tables, reduces memory usage, speeds history resets, and streamlines seeding across moves and null-moves. Result: leaner memory footprint and more efficient internal lookups with no change to search quality or evaluation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->