### PR TITLE
Prefetch joint correction history slots in do_move

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,46 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+// Tagged thread-local joint correction history.
+// Slot is a single 16-bit word: 11-bit signed value [-1023, +1023]
+// plus 5-bit tag.
+constexpr int      JOINT_CORR_BITS       = 17;
+constexpr size_t   JOINT_CORR_BASE_SIZE  = size_t(1) << JOINT_CORR_BITS;
+constexpr uint32_t JOINT_CORR_INDEX_MASK = uint32_t(JOINT_CORR_BASE_SIZE - 1);
+constexpr int      JOINT_CORR_TAG_BITS   = 5;
+using CorrTag                            = std::uint8_t;
+constexpr CorrTag JOINT_CORR_TAG_MASK    = CorrTag((1u << JOINT_CORR_TAG_BITS) - 1);
+constexpr int16_t JOINT_CORR_INIT        = 6;
+constexpr int16_t JOINT_CORR_NOK         = 8;
+
+// B-slot (4-ply-back) receives half the A-slot bonus, mirroring the
+// relative weights of the master continuation correction history.
+// Applied as a signed right shift (floor semantics).
+constexpr int JOINT_CORR_B_BONUS_SHIFT = 1;
+
+// log2(128). The per-table shared-history bonuses use weight fractions
+// with denominator 128; the division lowers to a signed right shift.
+constexpr int CORRECTION_WEIGHT_SHIFT = 7;
+static_assert((1 << CORRECTION_WEIGHT_SHIFT) == 128, "CORRECTION_WEIGHT_SHIFT must be log2(128)");
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((JOINT_CORR_BASE_SIZE & (JOINT_CORR_BASE_SIZE - 1)) == 0,
+              "JOINT_CORR_BASE_SIZE has to be a power of 2");
+
+// Guard the packed slot's signed value field against CORRECTION_HISTORY_LIMIT
+// growth. The field is 11-bit signed saturated to [-1023, +1023] (one codepoint
+// shaved off the negative end for symmetry). The gravity update
+// v + b - v*|b|/CORRECTION_HISTORY_LIMIT is a contraction whose fixed point
+// is +-CORRECTION_HISTORY_LIMIT; as long as CORRECTION_HISTORY_LIMIT <= 1024,
+// the saturating clamp in JointCorrSlot::pack() keeps v representable.
+static_assert(CORRECTION_HISTORY_LIMIT <= 1024,
+              "JointCorrSlot::value is an 11-bit saturated signed field; "
+              "widen the field or lower CORRECTION_HISTORY_LIMIT if this grows");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -214,6 +249,53 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+// Packed slot for the tagged thread-local joint correction history.
+// 11-bit signed value in bits [0..10] clamped to [-1023, +1023],
+// 5-bit tag in bits [11..15], stored as a single uint16_t word so
+// read and write compile to one 16-bit load and one 16-bit store
+// respectively. tag == 0 denotes an empty slot; tag generation
+// reserves 0 by remapping to 1.
+struct alignas(2) JointCorrSlot {
+    std::uint16_t word;
+
+    static constexpr int      WORD_BITS  = 16;
+    static constexpr int      VALUE_BITS = WORD_BITS - JOINT_CORR_TAG_BITS;
+    static constexpr int      SIGN_SHIFT = WORD_BITS - VALUE_BITS;  // sign-extend shift
+    static constexpr uint16_t VALUE_MASK = uint16_t((uint16_t(1) << VALUE_BITS) - 1u);
+    static constexpr int      VALUE_MAX  = (1 << (VALUE_BITS - 1)) - 1;  // +1023
+    static constexpr int      VALUE_MIN  = -VALUE_MAX;                   // -1023
+    static_assert(VALUE_BITS == 11, "JointCorrSlot value field must be 11 bits");
+
+    // log2(CORRECTION_HISTORY_LIMIT). The gravity update divides
+    // v*|b| by CORRECTION_HISTORY_LIMIT; since that limit is a power
+    // of two, the division lowers to a signed right shift. Computed
+    // at compile time so changing CORRECTION_HISTORY_LIMIT cannot
+    // desync the shift amount.
+    static constexpr int GRAVITY_SHIFT = [] {
+        int s = 0;
+        int n = CORRECTION_HISTORY_LIMIT;
+        while (n > 1)
+        {
+            n >>= 1;
+            ++s;
+        }
+        return s;
+    }();
+    static_assert((1 << GRAVITY_SHIFT) == CORRECTION_HISTORY_LIMIT,
+                  "CORRECTION_HISTORY_LIMIT must be a power of 2");
+
+    int     value() const { return std::int16_t(word << SIGN_SHIFT) >> SIGN_SHIFT; }
+    CorrTag tag() const { return CorrTag(word >> VALUE_BITS); }
+
+    static uint16_t pack(int v, CorrTag t) {
+        v = std::clamp(v, VALUE_MIN, VALUE_MAX);
+        return uint16_t((uint16_t(v) & VALUE_MASK) | uint16_t(uint16_t(t) << VALUE_BITS));
+    }
+};
+static_assert(sizeof(JointCorrSlot) == 2, "JointCorrSlot must be 2 bytes");
+
+using JointCorrectionHistory = std::array<JointCorrSlot, JOINT_CORR_BASE_SIZE>;
 
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -832,8 +832,10 @@ void Position::do_move(Move                      m,
                        bool                      givesCheck,
                        DirtyPiece&               dp,
                        DirtyThreats&             dts,
-                       const TranspositionTable* tt      = nullptr,
-                       const SharedHistories*    history = nullptr) {
+                       const TranspositionTable* tt,
+                       const SharedHistories*    history,
+                       const void*               jointCorrPfA,
+                       const void*               jointCorrPfB) {
 
     assert(m.is_ok());
     assert(&newSt != st);
@@ -1047,6 +1049,8 @@ void Position::do_move(Move                      m,
         prefetch(&history->minor_piece_correction_entry(*this));
         prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
         prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
+        prefetch(jointCorrPfA);
+        prefetch(jointCorrPfB);
     }
 
     // Set capture piece

--- a/src/position.h
+++ b/src/position.h
@@ -149,7 +149,9 @@ class Position {
                  DirtyPiece&               dp,
                  DirtyThreats&             dts,
                  const TranspositionTable* tt,
-                 const SharedHistories*    worker);
+                 const SharedHistories*    worker,
+                 const void*               jointCorrPfA,
+                 const void*               jointCorrPfB);
     void undo_move(Move m);
     void do_null_move(StateInfo& newSt);
     void undo_null_move();
@@ -412,7 +414,7 @@ inline void Position::swap_piece(Square s, Piece pc, DirtyThreats* const dts) {
 
 inline void Position::do_move(Move m, StateInfo& newSt, const TranspositionTable* tt = nullptr) {
     new (&scratch_dts) DirtyThreats;
-    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr);
+    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr, this, this);
 }
 
 inline StateInfo* Position::state() const { return st; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -81,18 +82,73 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// joint correction hash. NO_PIECE paired with SQ_A1 is the canonical
+// zero sentinel used before the root.
+static_assert(unsigned(NO_PIECE) == 0 && unsigned(SQ_A1) == 0,
+              "contcorr zero sentinel assumes NO_PIECE on SQ_A1 encodes to 0");
+static_assert(unsigned(PIECE_NB) * unsigned(SQUARE_NB) <= (1u << 10),
+              "contcorr_index must fit in 10 bits");
+unsigned contcorr_index(Piece pc, Square sq) { return unsigned(pc) * 64 + unsigned(sq); }
+
+// 64-bit mixer producing both a table index and a verification tag from
+// two 10-bit contcorrIndex inputs. Two rounds of multiply-xor-shift using
+// SplitMix64-derived odd multipliers; not the exact three-round SplitMix64
+// finalizer, but avalanches all 64 output bits so the tag is statistically
+// independent of the index.
+uint64_t contcorr_mix(uint32_t a, uint32_t b) {
+    uint64_t k = (uint64_t(a) << 10) | b;
+    k *= 0x9E3779B97F4A7C15ULL;
+    k ^= k >> 32;
+    k *= 0xBF58476D1CE4E5B9ULL;
+    k ^= k >> 27;
+    return k;
+}
+
+uint32_t contcorr_idx_from(uint64_t h) { return uint32_t(h) & JOINT_CORR_INDEX_MASK; }
+
+// Reserve tag == 0 as the empty-slot sentinel so a freshly cleared
+// (all-zeros) table behaves as if every access misses and returns INIT.
+CorrTag contcorr_tag_from(uint64_t h) {
+    CorrTag t = CorrTag(uint32_t(h >> JOINT_CORR_BITS)) & JOINT_CORR_TAG_MASK;
+    return t == 0 ? CorrTag(1) : t;
+}
+
+// Branchless read of one joint-correction slot. Sign-extends the
+// slot's value, blends with JOINT_CORR_INIT on tag mismatch.
+int joint_corr_read(uint16_t w_, CorrTag tag) {
+    const JointCorrSlot s{w_};
+    const int           v    = s.value();
+    const int32_t       mask = -int32_t(s.tag() != tag);
+    return (v & ~mask) | (int(JOINT_CORR_INIT) & mask);
+}
+
+// Gravity update of one joint-correction slot. One 16-bit load +
+// one 16-bit store (via JointCorrSlot::pack).
+void joint_corr_update(JointCorrSlot& s, CorrTag tag, int b) {
+    const JointCorrSlot s_ = s;
+    int                 v  = s_.tag() == tag ? s_.value() : int(JOINT_CORR_INIT);
+    v                      = v + b - ((v * std::abs(b)) >> JointCorrSlot::GRAVITY_SHIFT);
+    s.word                 = JointCorrSlot::pack(v, tag);
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+    int         cntcv;
+    if ((ss - 1)->currentMove.is_ok())
+    {
+        // One 16-bit load per slot, branchless tag check.
+        const uint16_t wA = w.jointCorrectionHistory[ss->contcorrIdxA].word;
+        const uint16_t wB = w.jointCorrectionHistory[ss->contcorrIdxB].word;
+        cntcv = joint_corr_read(wA, ss->contcorrTagA) + joint_corr_read(wB, ss->contcorrTagB);
+    }
+    else
+        cntcv = JOINT_CORR_NOK;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,23 +163,26 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
     shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.minor_piece_correction_entry(pos)[us].minor
+      << ((bonus * 153) >> CORRECTION_WEIGHT_SHIFT);
+    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite
+      << ((bonus * nonPawnWeight) >> CORRECTION_WEIGHT_SHIFT);
+    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack
+      << ((bonus * nonPawnWeight) >> CORRECTION_WEIGHT_SHIFT);
 
-    if (m.is_ok())
+    if ((ss - 1)->currentMove.is_ok())
     {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        // One 16-bit load + one 16-bit store per slot.
+        joint_corr_update(workerThread.jointCorrectionHistory[ss->contcorrIdxA], ss->contcorrTagA,
+                          bonus);
+        joint_corr_update(workerThread.jointCorrectionHistory[ss->contcorrIdxB], ss->contcorrTagB,
+                          bonus >> JOINT_CORR_B_BONUS_SHIFT);
     }
 }
 
@@ -285,9 +344,17 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->contcorrIdxA  = 0;
+        (ss - i)->contcorrTagA  = 0;
+        (ss - i)->contcorrIdxB  = 0;
+        (ss - i)->contcorrTagB  = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrIdxA = 0;
+    ss->contcorrTagA = 0;
+    ss->contcorrIdxB = 0;
+    ss->contcorrTagB = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
         (ss + i)->ply = i;
@@ -570,23 +637,47 @@ void Search::Worker::do_move(
     nodes.store(nodes.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
 
     auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
-    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory);
+
+    // Precompute child joint-corr addresses so Position::do_move can prefetch
+    // them alongside the shared-history prefetches. The piece on move.from_sq()
+    // before pos.do_move equals dirtyPiece.pc after pos.do_move (including for
+    // promotions, which keep the original pawn in dp.pc).
+    const uint32_t currIdx = contcorr_index(pos.piece_on(move.from_sq()), move.to_sq());
+    const uint64_t hA      = ss != nullptr ? contcorr_mix(currIdx, (ss - 1)->contcorrIndex) : 0;
+    const uint64_t hB      = ss != nullptr ? contcorr_mix(currIdx, (ss - 3)->contcorrIndex) : 0;
+    const JointCorrSlot* const pfA = &jointCorrectionHistory[contcorr_idx_from(hA)];
+    const JointCorrSlot* const pfB = &jointCorrectionHistory[contcorr_idx_from(hB)];
+
+    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory, pfA, pfB);
 
     if (ss != nullptr)
     {
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+
+        ss->contcorrIndex      = currIdx;
+        (ss + 1)->contcorrIdxA = contcorr_idx_from(hA);
+        (ss + 1)->contcorrTagA = contcorr_tag_from(hA);
+        (ss + 1)->contcorrIdxB = contcorr_idx_from(hB);
+        (ss + 1)->contcorrTagB = contcorr_tag_from(hB);
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = contcorr_index(NO_PIECE, SQ_A1);
+
+    const uint64_t hA      = contcorr_mix(ss->contcorrIndex, (ss - 1)->contcorrIndex);
+    const uint64_t hB      = contcorr_mix(ss->contcorrIndex, (ss - 3)->contcorrIndex);
+    (ss + 1)->contcorrIdxA = contcorr_idx_from(hA);
+    (ss + 1)->contcorrTagA = contcorr_tag_from(hA);
+    (ss + 1)->contcorrIdxB = contcorr_idx_from(hB);
+    (ss + 1)->contcorrTagB = contcorr_tag_from(hB);
+    prefetch(&jointCorrectionHistory[(ss + 1)->contcorrIdxA]);
+    prefetch(&jointCorrectionHistory[(ss + 1)->contcorrIdxB]);
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -608,9 +699,10 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    // Zero-initialize: tag == 0 is the empty-slot sentinel; read path
+    // returns JOINT_CORR_INIT for any access that does not match.
+    std::memset(jointCorrectionHistory.data(), 0,
+                sizeof(JointCorrSlot) * jointCorrectionHistory.size());
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,25 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*        pv;
+    PieceToHistory* continuationHistory;
+    int             ply;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    int             statScore;
+    int             moveCount;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
+    int             cutoffCnt;
+    int             reduction;
+    unsigned        contcorrIndex;
+    uint32_t        contcorrIdxA;
+    CorrTag         contcorrTagA;
+    uint32_t        contcorrIdxB;
+    CorrTag         contcorrTagB;
 };
 
 
@@ -331,9 +335,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory  captureHistory;
+    ContinuationHistory    continuationHistory[2][2];
+    JointCorrectionHistory jointCorrectionHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Bench: 2693603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal search algorithm's correction history tracking for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->