### PR TITLE
Use shift for gravity when D is a power of two

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -74,11 +74,21 @@ struct StatsEntry {
             return entry;
     }
 
+    static constexpr unsigned log2_pow2(int x) {
+        unsigned n = 0;
+        while ((1 << n) < x)
+            ++n;
+        return n;
+    }
+
     void operator<<(int bonus) {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
         T   val          = *this;
-        *this            = val + clampedBonus - val * std::abs(clampedBonus) / D;
+        if constexpr ((D & (D - 1)) == 0)
+            *this = val + clampedBonus - (int(val) * std::abs(clampedBonus) >> log2_pow2(D));
+        else
+            *this = val + clampedBonus - val * std::abs(clampedBonus) / D;
 
         assert(std::abs(T(*this)) <= D);
     }


### PR DESCRIPTION
Use >> log2(D) instead of / D in StatsEntry::operator<< when D is a compile-time
power of two, gated by if constexpr. Covers PawnHistory (D=8192), all
correction-history variants (D=1024), SharedContCorrPieceTo (D=1024),
TTMoveHistory (D=8192). Non-power-of-two tables untouched.

Semantic change: SAR floors where / truncates toward zero. Full-binary idiv
count drops 174 -> 169; the two out-of-line operator<< symbols go from cdq+idiv
to a single sar.

Bench: 2268702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized stat calculation performance through improved computation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->