### PR TITLE
Tagged hashed continuation correction history (i16, 128 KiB)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,18 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_CONTCORR_INDEX_BITS = 16;
+constexpr size_t   HASHED_CONTCORR_BASE_SIZE  = size_t(1) << HASHED_CONTCORR_INDEX_BITS;
+constexpr uint32_t HASHED_CONTCORR_INDEX_MASK = uint32_t(HASHED_CONTCORR_BASE_SIZE - 1);
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_CONTCORR_BASE_SIZE & (HASHED_CONTCORR_BASE_SIZE - 1)) == 0,
+              "HASHED_CONTCORR_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -214,6 +221,60 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+// Packed slot for the tagged thread-local hashed continuation-correction
+// history. 11-bit signed value in bits [0..10] clamped to [-1023, +1023],
+// 5-bit tag in bits [11..15], stored as a single uint16_t word so read and
+// write compile to one 16-bit load and one 16-bit store respectively.
+// tag == 0 denotes an empty slot; tag generation reserves 0 by remapping to 1.
+struct alignas(2) HashedContCorrSlot {
+    using Tag = std::uint8_t;
+
+    static constexpr int     TAG_BITS = 5;
+    static constexpr Tag     TAG_MASK = Tag((1u << TAG_BITS) - 1);
+    static constexpr int16_t INIT     = 6;
+    static constexpr int16_t NOK      = 8;
+
+    static constexpr int      WORD_BITS  = 16;
+    static constexpr int      VALUE_BITS = WORD_BITS - TAG_BITS;
+    static constexpr int      SIGN_SHIFT = WORD_BITS - VALUE_BITS;  // sign-extend shift
+    static constexpr uint16_t VALUE_MASK = uint16_t((uint16_t(1) << VALUE_BITS) - 1u);
+    static constexpr int      VALUE_MAX  = (1 << (VALUE_BITS - 1)) - 1;  // +1023
+    static constexpr int      VALUE_MIN  = -VALUE_MAX;                   // -1023
+    static_assert(VALUE_BITS == 11, "HashedContCorrSlot value field must be 11 bits");
+    static_assert(CORRECTION_HISTORY_LIMIT <= 1024,
+                  "value is an 11-bit saturated signed field; widen the field or "
+                  "lower CORRECTION_HISTORY_LIMIT if this grows");
+
+    std::uint16_t word;
+
+    int value() const { return std::int16_t(word << SIGN_SHIFT) >> SIGN_SHIFT; }
+    Tag tag() const { return Tag(word >> VALUE_BITS); }
+
+    static uint16_t pack(int v, Tag t) {
+        v = std::clamp(v, VALUE_MIN, VALUE_MAX);
+        return uint16_t((uint16_t(v) & VALUE_MASK) | uint16_t(uint16_t(t) << VALUE_BITS));
+    }
+
+    // Branchless read: sign-extends the slot's value, blends with INIT
+    // on tag mismatch.
+    static int read(uint16_t w, Tag t) {
+        const HashedContCorrSlot s{w};
+        const int                v    = s.value();
+        const int32_t            mask = -int32_t(s.tag() != t);
+        return (v & ~mask) | (int(INIT) & mask);
+    }
+
+    static void update(HashedContCorrSlot& s, Tag t, int b) {
+        const HashedContCorrSlot sv = s;
+        int                      v  = sv.tag() == t ? sv.value() : int(INIT);
+        v                           = v + b - v * std::abs(b) / CORRECTION_HISTORY_LIMIT;
+        s.word                      = pack(v, t);
+    }
+};
+static_assert(sizeof(HashedContCorrSlot) == 2, "HashedContCorrSlot must be 2 bytes");
+
+using HashedContCorrHistory = std::array<HashedContCorrSlot, HASHED_CONTCORR_BASE_SIZE>;
 
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -81,18 +82,54 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// hashed continuation-correction hash. NO_PIECE paired with SQ_A1 is the canonical
+// zero sentinel used before the root.
+static_assert(unsigned(NO_PIECE) == 0 && unsigned(SQ_A1) == 0,
+              "contcorr zero sentinel assumes NO_PIECE on SQ_A1 encodes to 0");
+static_assert(unsigned(PIECE_NB) * unsigned(SQUARE_NB) <= (1u << 10),
+              "contcorr_index must fit in 10 bits");
+unsigned contcorr_index(Piece pc, Square sq) { return unsigned(pc) * 64 + unsigned(sq); }
+
+// 64-bit mixer producing both a table index and a verification tag from
+// two 10-bit contcorrIndex inputs.
+uint64_t contcorr_mix(uint32_t a, uint32_t b) {
+    uint64_t k = (uint64_t(a) << 10) | b;
+    k *= 0x9E3779B97F4A7C15ULL;
+    k ^= k >> 32;
+    k *= 0xBF58476D1CE4E5B9ULL;
+    k ^= k >> 27;
+    return k;
+}
+
+uint32_t contcorr_idx_from(uint64_t h) { return uint32_t(h) & HASHED_CONTCORR_INDEX_MASK; }
+
+// Reserve tag == 0 as the empty-slot sentinel so a freshly cleared
+// (all-zeros) table behaves as if every access misses and returns INIT.
+HashedContCorrSlot::Tag contcorr_tag_from(uint64_t h) {
+    auto t = HashedContCorrSlot::Tag(uint32_t(h >> HASHED_CONTCORR_INDEX_BITS))
+           & HashedContCorrSlot::TAG_MASK;
+    return t == 0 ? HashedContCorrSlot::Tag(1) : t;
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+
+    int cntcv;
+    if ((ss - 1)->currentMove.is_ok())
+    {
+        const uint16_t wA = w.hashedContCorrHistory[ss->contcorrIdxA].word;
+        const uint16_t wB = w.hashedContCorrHistory[ss->contcorrIdxB].word;
+        cntcv             = HashedContCorrSlot::read(wA, ss->contcorrTagA)
+              + HashedContCorrSlot::read(wB, ss->contcorrTagB);
+    }
+    else
+        cntcv = HashedContCorrSlot::NOK;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,7 +144,6 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 187;
@@ -118,12 +154,12 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
+    if ((ss - 1)->currentMove.is_ok())
     {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        HashedContCorrSlot::update(workerThread.hashedContCorrHistory[ss->contcorrIdxA],
+                                   ss->contcorrTagA, bonus * 126 / 128);
+        HashedContCorrSlot::update(workerThread.hashedContCorrHistory[ss->contcorrIdxB],
+                                   ss->contcorrTagB, bonus * 63 / 128);
     }
 }
 
@@ -285,9 +321,17 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->contcorrIdxA  = 0;
+        (ss - i)->contcorrTagA  = 0;
+        (ss - i)->contcorrIdxB  = 0;
+        (ss - i)->contcorrTagB  = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrIdxA = 0;
+    ss->contcorrTagA = 0;
+    ss->contcorrIdxB = 0;
+    ss->contcorrTagB = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
         (ss + i)->ply = i;
@@ -577,16 +621,24 @@ void Search::Worker::do_move(
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+
+        const uint32_t currIdx = contcorr_index(dirtyPiece.pc, move.to_sq());
+        const uint64_t hA      = contcorr_mix(currIdx, (ss - 1)->contcorrIndex);
+        const uint64_t hB      = contcorr_mix(currIdx, (ss - 3)->contcorrIndex);
+
+        ss->contcorrIndex      = currIdx;
+        (ss + 1)->contcorrIdxA = contcorr_idx_from(hA);
+        (ss + 1)->contcorrTagA = contcorr_tag_from(hA);
+        (ss + 1)->contcorrIdxB = contcorr_idx_from(hB);
+        (ss + 1)->contcorrTagB = contcorr_tag_from(hB);
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = contcorr_index(NO_PIECE, SQ_A1);
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -608,9 +660,10 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    // Zero-initialize: tag == 0 is the empty-slot sentinel; read path
+    // returns HashedContCorrSlot::INIT for any access that does not match.
+    std::memset(hashedContCorrHistory.data(), 0,
+                sizeof(HashedContCorrSlot) * hashedContCorrHistory.size());
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,25 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*                pv;
+    PieceToHistory*         continuationHistory;
+    int                     ply;
+    Move                    currentMove;
+    Move                    excludedMove;
+    Value                   staticEval;
+    int                     statScore;
+    int                     moveCount;
+    bool                    inCheck;
+    bool                    ttPv;
+    bool                    ttHit;
+    bool                    followPV;
+    int                     cutoffCnt;
+    int                     reduction;
+    unsigned                contcorrIndex;
+    uint32_t                contcorrIdxA;
+    HashedContCorrSlot::Tag contcorrTagA;
+    uint32_t                contcorrIdxB;
+    HashedContCorrSlot::Tag contcorrTagB;
 };
 
 
@@ -331,9 +335,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
+    HashedContCorrHistory hashedContCorrHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Replaces the shared 2-D continuationCorrectionHistory[PIECE_NB][SQUARE_NB] table with a per-thread tagged hashed table indexed by a 64-bit mix of the current move's (piece, square) and those of the previous two plies. Slot is a single 16-bit word: 5-bit tag plus 11-bit signed value clamped to [-1023, +1023]. Index width is 16 bits, giving a 128 KiB per-thread table.

Slot-internal constants (tag width, init/nok sentinels, value geometry, pack/read/update helpers) live inside HashedContCorrSlot; only size-related constants (HASHED_CONTCORR_INDEX_BITS, HASHED_CONTCORR_BASE_SIZE, HASHED_CONTCORR_INDEX_MASK) are at namespace scope to feed the HashedContCorrHistory array typedef.

Bench: 2923429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal continuation-correction history storage with a more efficient hashed indexing scheme, reducing memory footprint and improving lookup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->