### PR TITLE
Tag shared corrhist slots with 5-bit collision discriminator

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -114,9 +114,6 @@ static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT,
 
 using CorrhistTag = std::uint8_t;
 
-// Extract the topmost TAG_BITS of the 64-bit key as the tag. Using the top
-// bits keeps the tag disjoint from any low-bit index width used by the
-// shared correction history (DynStats sized threadCount * CORRHIST_BASE_SIZE).
 inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
     const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
     return t == 0 ? CorrhistTag(1) : t;
@@ -125,11 +122,12 @@ inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
 struct alignas(2) CorrhistTaggedSlot {
     std::atomic<std::uint16_t> word{0};
 
-    // Clear to empty (tag=0). Used by DynStats::clear_range via
-    // CorrectionBundle::operator=.
-    void operator=(int) { word.store(0, std::memory_order_relaxed); }
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
 
-    // Branchless read: sign-extend value, blend with INIT on tag mismatch.
     int read(CorrhistTag tag) const {
         const std::uint16_t w         = word.load(std::memory_order_relaxed);
         const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
@@ -152,11 +150,8 @@ struct alignas(2) CorrhistTaggedSlot {
         word.store(newWord, std::memory_order_relaxed);
     }
 };
-static_assert(sizeof(CorrhistTaggedSlot) == 2,
-              "CorrhistTaggedSlot must remain 2 bytes (memory-neutral vs int16_t)");
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
 
-// Proxy returned by SharedHistories correction accessors: carries the slot
-// pointer and the tag derived from the position key used to reach the slot.
 struct CorrhistAccess {
     CorrhistTaggedSlot* slot;
     CorrhistTag         tag;
@@ -252,9 +247,9 @@ struct CorrectionBundle {
     CorrhistTaggedSlot nonPawnWhite;
     CorrhistTaggedSlot nonPawnBlack;
 
-    void operator=(T /*val*/) {
-        // Tagged slots only have one valid initialization (empty: tag=0). Master
-        // only ever fills shared corrhist with 0, so ignoring val is safe.
+    void operator=(T val) {
+        assert(val == 0);
+        (void) val;
         pawn         = 0;
         minor        = 0;
         nonPawnWhite = 0;

--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,83 @@ enum StatsType {
     Captures
 };
 
+constexpr int corrhist_bit_width(unsigned x) {
+    int n = 0;
+    while ((1u << n) < x)
+        ++n;
+    return n;
+}
+
+constexpr int      CORRHIST_VALUE_MIN     = -1024;
+constexpr int      CORRHIST_VALUE_MAX     = -CORRHIST_VALUE_MIN - 1;
+constexpr int      CORRHIST_SLOT_BITS     = int(sizeof(std::uint16_t) * 8);
+constexpr int      CORRHIST_VALUE_BITS    = corrhist_bit_width(unsigned(-CORRHIST_VALUE_MIN)) + 1;
+constexpr int      CORRHIST_TAG_BITS      = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr int      CORRHIST_TAG_KEY_SHIFT = int(sizeof(std::uint64_t) * 8) - CORRHIST_TAG_BITS;
+constexpr uint16_t CORRHIST_VALUE_MASK    = uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr uint16_t CORRHIST_TAG_RAW_MASK  = uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+constexpr int      CORRHIST_INIT_VALUE    = 0;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS,
+              "Value and tag must fill the atomic slot exactly");
+static_assert(CORRHIST_TAG_BITS >= 1, "Need at least one bit of tag discrimination");
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT,
+              "Value range must match master's correction-history gravity divisor");
+
+using CorrhistTag = std::uint8_t;
+
+// Extract the topmost TAG_BITS of the 64-bit key as the tag. Using the top
+// bits keeps the tag disjoint from any low-bit index width used by the
+// shared correction history (DynStats sized threadCount * CORRHIST_BASE_SIZE).
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+    return t == 0 ? CorrhistTag(1) : t;
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::uint16_t> word{0};
+
+    // Clear to empty (tag=0). Used by DynStats::clear_range via
+    // CorrectionBundle::operator=.
+    void operator=(int) { word.store(0, std::memory_order_relaxed); }
+
+    // Branchless read: sign-extend value, blend with INIT on tag mismatch.
+    int read(CorrhistTag tag) const {
+        const std::uint16_t w         = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const int           v         = std::int16_t(w << CORRHIST_TAG_BITS) >> CORRHIST_TAG_BITS;
+        const std::int32_t  mask      = -std::int32_t(storedTag != tag);
+        return (v & ~mask) | (CORRHIST_INIT_VALUE & mask);
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        constexpr int       D            = -CORRHIST_VALUE_MIN;
+        const int           clampedBonus = std::clamp(bonus, -D, D);
+        const std::uint16_t w            = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag    = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        int v = (storedTag == tag) ? (std::int16_t(w << CORRHIST_TAG_BITS) >> CORRHIST_TAG_BITS)
+                                   : CORRHIST_INIT_VALUE;
+        v     = v + clampedBonus - v * std::abs(clampedBonus) / D;
+        v     = std::clamp(v, CORRHIST_VALUE_MIN, CORRHIST_VALUE_MAX);
+        const std::uint16_t newWord =
+          (std::uint16_t(v) & CORRHIST_VALUE_MASK) | (std::uint16_t(tag) << CORRHIST_VALUE_BITS);
+        word.store(newWord, std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2,
+              "CorrhistTaggedSlot must remain 2 bytes (memory-neutral vs int16_t)");
+
+// Proxy returned by SharedHistories correction accessors: carries the slot
+// pointer and the tag derived from the position key used to reach the slot.
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline int  read() const { return slot->read(tag); }
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+    inline sf_always_inline      operator int() const { return read(); }
+};
+
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
@@ -167,16 +244,21 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
+                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
 
-    void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
+
+    void operator=(T /*val*/) {
+        // Tagged slots only have one valid initialization (empty: tag=0). Master
+        // only ever fills shared corrhist with 0, so ignoring val is safe.
+        pawn         = 0;
+        minor        = 0;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -260,11 +342,34 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
-    UnifiedCorrectionHistory correctionHistory;
-    PawnHistory              pawnHistory;
+    CorrhistAccess pawn_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k = pos.pawn_key();
+        return {&get_bundle(k, us).pawn, corrhist_tag_from(k)};
+    }
+    CorrhistAccess minor_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k = pos.minor_piece_key();
+        return {&get_bundle(k, us).minor, corrhist_tag_from(k)};
+    }
+    template<Color Us>
+    CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k      = pos.non_pawn_key(Us);
+        auto&               bundle = get_bundle(k, us);
+        if constexpr (Us == WHITE)
+            return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+        else
+            return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+    }
+
+    mutable UnifiedCorrectionHistory correctionHistory;
+    PawnHistory                      pawnHistory;
 
 
    private:
+    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                         Color         us) const {
+        return correctionHistory[key & sizeMinus1][us];
+    }
+
     size_t sizeMinus1, pawnHistSizeMinus1;
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,10 +85,10 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
+    const int   pcv    = shared.pawn_correction_access(pos, us).read();
+    const int   micv   = shared.minor_correction_access(pos, us).read();
+    const int   wnpcv  = shared.nonpawn_correction_access<WHITE>(pos, us).read();
+    const int   bnpcv  = shared.nonpawn_correction_access<BLACK>(pos, us).read();
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
@@ -113,10 +113,10 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_access(pos, us) << bonus;
+    shared.minor_correction_access(pos, us) << bonus * 153 / 128;
+    shared.nonpawn_correction_access<WHITE>(pos, us) << bonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_access<BLACK>(pos, us) << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {


### PR DESCRIPTION
Reuses the 5 spare bits in each int16_t StatsEntry (values clamp at
CORRECTION_HISTORY_LIMIT = 1024, needing only 11 signed bits) to tag the
four shared correction bundles (pawn, minor, nonPawnWhite, nonPawnBlack)
with bits 16..20 of the position key. On tag mismatch, read returns
CORRHIST_INIT_VALUE = 0 via a branchless xor-blend; write evicts the
prior occupant and stamps our tag. Filters collision aliasing that
master's direct-indexed tables silently accumulate.

Memory-neutral: same 16-bit atomic slot, same CORRHIST_BASE_SIZE = 2^16.
Value range clipped from [-1024, +1024] to [-1024, +1023] to fit 11
signed bits (one-unit saturation shift).

Atomics: relaxed load and store, same race semantics as master's
atomic<int16_t> operator<<. No new CAS loop.

Codegen: correction_value 131 insns (no new conditional jumps, no new
idiv). update_correction_history calls an out-of-line 40-insn helper
for each of 4 bundles; /1024 becomes sar 0xa (no idiv for the gravity
step).

Bench: 2918708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal correction-history storage and access were reworked to use tagged per-slot values and new tag-aware accessors for reads and writes.
  * Access now validates tags on read and routes updates through proxy accessors.
  * No changes to existing public interfaces; no user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->