### PR TITLE
Split shared corrhist: grow nonpawn bundles to BASE_SIZE_NONPAWN = 2^17

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -89,28 +89,35 @@ enum StatsType {
     Captures
 };
 
-constexpr int corrhist_bit_width(unsigned x) {
-    int n = 0;
-    while ((1u << n) < x)
-        ++n;
-    return n;
-}
+constexpr int           CORRHIST_VALUE_MIN     = -1024;
+constexpr int           CORRHIST_VALUE_MAX     = -CORRHIST_VALUE_MIN - 1;
+constexpr int           CORRHIST_INIT_VALUE    = 0;
+constexpr std::size_t   CORRHIST_SLOT_BITS     = sizeof(std::uint16_t) * 8;
+constexpr std::size_t   CORRHIST_VALUE_BITS    = ilog2(std::size_t(-CORRHIST_VALUE_MIN)) + 1;
+constexpr std::size_t   CORRHIST_TAG_BITS      = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr std::size_t   CORRHIST_KEY_BITS      = sizeof(std::uint64_t) * 8;
+constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT = CORRHIST_KEY_BITS - CORRHIST_TAG_BITS;
+constexpr std::uint16_t CORRHIST_VALUE_MASK    = std::uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr std::uint16_t CORRHIST_TAG_RAW_MASK  = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
 
-constexpr int      CORRHIST_VALUE_MIN     = -1024;
-constexpr int      CORRHIST_VALUE_MAX     = -CORRHIST_VALUE_MIN - 1;
-constexpr int      CORRHIST_SLOT_BITS     = int(sizeof(std::uint16_t) * 8);
-constexpr int      CORRHIST_VALUE_BITS    = corrhist_bit_width(unsigned(-CORRHIST_VALUE_MIN)) + 1;
-constexpr int      CORRHIST_TAG_BITS      = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
-constexpr int      CORRHIST_TAG_KEY_SHIFT = int(sizeof(std::uint64_t) * 8) - CORRHIST_TAG_BITS;
-constexpr uint16_t CORRHIST_VALUE_MASK    = uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
-constexpr uint16_t CORRHIST_TAG_RAW_MASK  = uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
-constexpr int      CORRHIST_INIT_VALUE    = 0;
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS     = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MAX     = CORRHIST_DOMAIN_LOG2_PAWN;
 
-static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS,
-              "Value and tag must fill the atomic slot exactly");
-static_assert(CORRHIST_TAG_BITS >= 1, "Need at least one bit of tag discrimination");
-static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT,
-              "Value range must match master's correction-history gravity divisor");
+constexpr std::size_t CORRHIST_MAX_THREADS_STRUCT =
+  std::size_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS_DATA =
+  std::size_t(1) << (CORRHIST_DOMAIN_LOG2_MAX - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS =
+  std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA);
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
+static_assert(CORRHIST_TAG_BITS >= 1);
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_MAX);
 
 using CorrhistTag = std::uint8_t;
 
@@ -298,7 +305,7 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(threadCount),
+        correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;

--- a/src/history.h
+++ b/src/history.h
@@ -35,17 +35,21 @@
 
 namespace Stockfish {
 
-constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
-constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
-constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
-constexpr int CORRECTION_HISTORY_LIMIT = 1024;
-constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+constexpr int PAWN_HISTORY_BASE_SIZE     = 8192;  // has to be a power of 2
+constexpr int UINT_16_HISTORY_SIZE       = std::numeric_limits<uint16_t>::max() + 1;
+constexpr int CORRHIST_BASE_SIZE         = UINT_16_HISTORY_SIZE;
+constexpr int CORRHIST_BASE_SIZE_NONPAWN = 1 << 17;
+constexpr int CORRECTION_HISTORY_LIMIT   = 1024;
+constexpr int LOW_PLY_HISTORY_SIZE       = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((CORRHIST_BASE_SIZE_NONPAWN & (CORRHIST_BASE_SIZE_NONPAWN - 1)) == 0,
+              "CORRHIST_BASE_SIZE_NONPAWN has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -100,24 +104,38 @@ constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT = CORRHIST_KEY_BITS - CORRHIST_TA
 constexpr std::uint16_t CORRHIST_VALUE_MASK    = std::uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
 constexpr std::uint16_t CORRHIST_TAG_RAW_MASK  = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
 
-constexpr std::size_t CORRHIST_INDEX_BASE_BITS     = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS_NONPAWN =
+  ilog2(std::size_t(CORRHIST_BASE_SIZE_NONPAWN));
+
 constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
 constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
 constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
-constexpr std::size_t CORRHIST_DOMAIN_LOG2_MAX     = CORRHIST_DOMAIN_LOG2_PAWN;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWNMINOR =
+  CORRHIST_DOMAIN_LOG2_PAWN > CORRHIST_DOMAIN_LOG2_MINOR ? CORRHIST_DOMAIN_LOG2_PAWN
+                                                         : CORRHIST_DOMAIN_LOG2_MINOR;
 
 constexpr std::size_t CORRHIST_MAX_THREADS_STRUCT =
   std::size_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
 constexpr std::size_t CORRHIST_MAX_THREADS_DATA =
-  std::size_t(1) << (CORRHIST_DOMAIN_LOG2_MAX - CORRHIST_INDEX_BASE_BITS);
+  std::size_t(1) << (CORRHIST_DOMAIN_LOG2_PAWNMINOR - CORRHIST_INDEX_BASE_BITS);
 constexpr std::size_t CORRHIST_MAX_THREADS =
   std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA);
+
+constexpr std::size_t CORRHIST_MAX_THREADS_STRUCT_NONPAWN =
+  std::size_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS_NONPAWN);
+constexpr std::size_t CORRHIST_MAX_THREADS_DATA_NONPAWN =
+  std::size_t(1) << (CORRHIST_DOMAIN_LOG2_NONPAWN - CORRHIST_INDEX_BASE_BITS_NONPAWN);
+constexpr std::size_t CORRHIST_MAX_THREADS_NONPAWN =
+  std::min(CORRHIST_MAX_THREADS_STRUCT_NONPAWN, CORRHIST_MAX_THREADS_DATA_NONPAWN);
 
 static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
 static_assert(CORRHIST_TAG_BITS >= 1);
 static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
 static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
-static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_MAX);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_PAWNMINOR);
+static_assert(CORRHIST_INDEX_BASE_BITS_NONPAWN <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS_NONPAWN <= CORRHIST_DOMAIN_LOG2_NONPAWN);
 
 using CorrhistTag = std::uint8_t;
 
@@ -245,20 +263,30 @@ enum CorrHistType {
 };
 
 template<typename T, int D>
-struct CorrectionBundle {
-    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
-                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
+struct CorrectionBundlePawnMinor {
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT);
 
     CorrhistTaggedSlot pawn;
     CorrhistTaggedSlot minor;
+
+    void operator=(T val) {
+        assert(val == 0);
+        (void) val;
+        pawn  = 0;
+        minor = 0;
+    }
+};
+
+template<typename T, int D>
+struct CorrectionBundleNonPawn {
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT);
+
     CorrhistTaggedSlot nonPawnWhite;
     CorrhistTaggedSlot nonPawnBlack;
 
     void operator=(T val) {
         assert(val == 0);
         (void) val;
-        pawn         = 0;
-        minor        = 0;
         nonPawnWhite = 0;
         nonPawnBlack = 0;
     }
@@ -290,9 +318,13 @@ struct CorrHistTypedef<NonPawn> {
 
 }
 
-using UnifiedCorrectionHistory =
-  DynStats<MultiArray<CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
+using UnifiedCorrectionHistoryPawnMinor =
+  DynStats<MultiArray<CorrectionBundlePawnMinor<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
            CORRHIST_BASE_SIZE>;
+
+using UnifiedCorrectionHistoryNonPawn =
+  DynStats<MultiArray<CorrectionBundleNonPawn<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
+           CORRHIST_BASE_SIZE_NONPAWN>;
 
 template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
@@ -305,14 +337,16 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS)),
+        correctionHistoryPawnMinor(std::min(threadCount, CORRHIST_MAX_THREADS)),
+        correctionHistoryNonPawn(std::min(threadCount, CORRHIST_MAX_THREADS_NONPAWN)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
-        sizeMinus1         = correctionHistory.get_size() - 1;
-        pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        sizeMinus1PawnMinor = correctionHistoryPawnMinor.get_size() - 1;
+        sizeMinus1NonPawn   = correctionHistoryNonPawn.get_size() - 1;
+        pawnHistSizeMinus1  = pawnHistory.get_size() - 1;
     }
 
-    size_t get_size() const { return sizeMinus1 + 1; }
+    size_t get_size() const { return sizeMinus1PawnMinor + 1; }
 
     auto& pawn_entry(const Position& pos) {
         return pawnHistory[pos.pawn_key() & pawnHistSizeMinus1];
@@ -322,57 +356,54 @@ struct SharedHistories {
     }
 
     auto& pawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.pawn_key() & sizeMinus1PawnMinor];
     }
     const auto& pawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.pawn_key() & sizeMinus1PawnMinor];
     }
 
     auto& minor_piece_correction_entry(const Position& pos) {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.minor_piece_key() & sizeMinus1PawnMinor];
     }
     const auto& minor_piece_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.minor_piece_key() & sizeMinus1PawnMinor];
     }
 
     template<Color c>
     auto& nonpawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+        return correctionHistoryNonPawn[pos.non_pawn_key(c) & sizeMinus1NonPawn];
     }
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+        return correctionHistoryNonPawn[pos.non_pawn_key(c) & sizeMinus1NonPawn];
     }
 
     CorrhistAccess pawn_correction_access(const Position& pos, Color us) const {
         const std::uint64_t k = pos.pawn_key();
-        return {&get_bundle(k, us).pawn, corrhist_tag_from(k)};
+        return {&correctionHistoryPawnMinor[k & sizeMinus1PawnMinor][us].pawn,
+                corrhist_tag_from(k)};
     }
     CorrhistAccess minor_correction_access(const Position& pos, Color us) const {
         const std::uint64_t k = pos.minor_piece_key();
-        return {&get_bundle(k, us).minor, corrhist_tag_from(k)};
+        return {&correctionHistoryPawnMinor[k & sizeMinus1PawnMinor][us].minor,
+                corrhist_tag_from(k)};
     }
     template<Color Us>
     CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) const {
         const std::uint64_t k      = pos.non_pawn_key(Us);
-        auto&               bundle = get_bundle(k, us);
+        auto&               bundle = correctionHistoryNonPawn[k & sizeMinus1NonPawn][us];
         if constexpr (Us == WHITE)
             return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
         else
             return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
     }
 
-    mutable UnifiedCorrectionHistory correctionHistory;
-    PawnHistory                      pawnHistory;
-
+    mutable UnifiedCorrectionHistoryPawnMinor correctionHistoryPawnMinor;
+    mutable UnifiedCorrectionHistoryNonPawn   correctionHistoryNonPawn;
+    PawnHistory                               pawnHistory;
 
    private:
-    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
-                                                                         Color         us) const {
-        return correctionHistory[key & sizeMinus1][us];
-    }
-
-    size_t sizeMinus1, pawnHistSizeMinus1;
+    size_t sizeMinus1PawnMinor, sizeMinus1NonPawn, pawnHistSizeMinus1;
 };
 
 }  // namespace Stockfish

--- a/src/history.h
+++ b/src/history.h
@@ -114,9 +114,6 @@ static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT,
 
 using CorrhistTag = std::uint8_t;
 
-// Extract the topmost TAG_BITS of the 64-bit key as the tag. Using the top
-// bits keeps the tag disjoint from any low-bit index width used by the
-// shared correction history (DynStats sized threadCount * CORRHIST_BASE_SIZE).
 inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
     const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
     return t == 0 ? CorrhistTag(1) : t;
@@ -125,11 +122,12 @@ inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
 struct alignas(2) CorrhistTaggedSlot {
     std::atomic<std::uint16_t> word{0};
 
-    // Clear to empty (tag=0). Used by DynStats::clear_range via
-    // CorrectionBundle::operator=.
-    void operator=(int) { word.store(0, std::memory_order_relaxed); }
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
 
-    // Branchless read: sign-extend value, blend with INIT on tag mismatch.
     int read(CorrhistTag tag) const {
         const std::uint16_t w         = word.load(std::memory_order_relaxed);
         const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
@@ -152,11 +150,8 @@ struct alignas(2) CorrhistTaggedSlot {
         word.store(newWord, std::memory_order_relaxed);
     }
 };
-static_assert(sizeof(CorrhistTaggedSlot) == 2,
-              "CorrhistTaggedSlot must remain 2 bytes (memory-neutral vs int16_t)");
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
 
-// Proxy returned by SharedHistories correction accessors: carries the slot
-// pointer and the tag derived from the position key used to reach the slot.
 struct CorrhistAccess {
     CorrhistTaggedSlot* slot;
     CorrhistTag         tag;
@@ -252,9 +247,9 @@ struct CorrectionBundle {
     CorrhistTaggedSlot nonPawnWhite;
     CorrhistTaggedSlot nonPawnBlack;
 
-    void operator=(T /*val*/) {
-        // Tagged slots only have one valid initialization (empty: tag=0). Master
-        // only ever fills shared corrhist with 0, so ignoring val is safe.
+    void operator=(T val) {
+        assert(val == 0);
+        (void) val;
         pawn         = 0;
         minor        = 0;
         nonPawnWhite = 0;

--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,83 @@ enum StatsType {
     Captures
 };
 
+constexpr int corrhist_bit_width(unsigned x) {
+    int n = 0;
+    while ((1u << n) < x)
+        ++n;
+    return n;
+}
+
+constexpr int      CORRHIST_VALUE_MIN     = -1024;
+constexpr int      CORRHIST_VALUE_MAX     = -CORRHIST_VALUE_MIN - 1;
+constexpr int      CORRHIST_SLOT_BITS     = int(sizeof(std::uint16_t) * 8);
+constexpr int      CORRHIST_VALUE_BITS    = corrhist_bit_width(unsigned(-CORRHIST_VALUE_MIN)) + 1;
+constexpr int      CORRHIST_TAG_BITS      = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr int      CORRHIST_TAG_KEY_SHIFT = int(sizeof(std::uint64_t) * 8) - CORRHIST_TAG_BITS;
+constexpr uint16_t CORRHIST_VALUE_MASK    = uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr uint16_t CORRHIST_TAG_RAW_MASK  = uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+constexpr int      CORRHIST_INIT_VALUE    = 0;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS,
+              "Value and tag must fill the atomic slot exactly");
+static_assert(CORRHIST_TAG_BITS >= 1, "Need at least one bit of tag discrimination");
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT,
+              "Value range must match master's correction-history gravity divisor");
+
+using CorrhistTag = std::uint8_t;
+
+// Extract the topmost TAG_BITS of the 64-bit key as the tag. Using the top
+// bits keeps the tag disjoint from any low-bit index width used by the
+// shared correction history (DynStats sized threadCount * CORRHIST_BASE_SIZE).
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+    return t == 0 ? CorrhistTag(1) : t;
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::uint16_t> word{0};
+
+    // Clear to empty (tag=0). Used by DynStats::clear_range via
+    // CorrectionBundle::operator=.
+    void operator=(int) { word.store(0, std::memory_order_relaxed); }
+
+    // Branchless read: sign-extend value, blend with INIT on tag mismatch.
+    int read(CorrhistTag tag) const {
+        const std::uint16_t w         = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const int           v         = std::int16_t(w << CORRHIST_TAG_BITS) >> CORRHIST_TAG_BITS;
+        const std::int32_t  mask      = -std::int32_t(storedTag != tag);
+        return (v & ~mask) | (CORRHIST_INIT_VALUE & mask);
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        constexpr int       D            = -CORRHIST_VALUE_MIN;
+        const int           clampedBonus = std::clamp(bonus, -D, D);
+        const std::uint16_t w            = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag    = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        int v = (storedTag == tag) ? (std::int16_t(w << CORRHIST_TAG_BITS) >> CORRHIST_TAG_BITS)
+                                   : CORRHIST_INIT_VALUE;
+        v     = v + clampedBonus - v * std::abs(clampedBonus) / D;
+        v     = std::clamp(v, CORRHIST_VALUE_MIN, CORRHIST_VALUE_MAX);
+        const std::uint16_t newWord =
+          (std::uint16_t(v) & CORRHIST_VALUE_MASK) | (std::uint16_t(tag) << CORRHIST_VALUE_BITS);
+        word.store(newWord, std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2,
+              "CorrhistTaggedSlot must remain 2 bytes (memory-neutral vs int16_t)");
+
+// Proxy returned by SharedHistories correction accessors: carries the slot
+// pointer and the tag derived from the position key used to reach the slot.
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline int  read() const { return slot->read(tag); }
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+    inline sf_always_inline      operator int() const { return read(); }
+};
+
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
@@ -167,16 +244,21 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
+                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
 
-    void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
+
+    void operator=(T /*val*/) {
+        // Tagged slots only have one valid initialization (empty: tag=0). Master
+        // only ever fills shared corrhist with 0, so ignoring val is safe.
+        pawn         = 0;
+        minor        = 0;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -260,11 +342,34 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
-    UnifiedCorrectionHistory correctionHistory;
-    PawnHistory              pawnHistory;
+    CorrhistAccess pawn_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k = pos.pawn_key();
+        return {&get_bundle(k, us).pawn, corrhist_tag_from(k)};
+    }
+    CorrhistAccess minor_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k = pos.minor_piece_key();
+        return {&get_bundle(k, us).minor, corrhist_tag_from(k)};
+    }
+    template<Color Us>
+    CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) const {
+        const std::uint64_t k      = pos.non_pawn_key(Us);
+        auto&               bundle = get_bundle(k, us);
+        if constexpr (Us == WHITE)
+            return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+        else
+            return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+    }
+
+    mutable UnifiedCorrectionHistory correctionHistory;
+    PawnHistory                      pawnHistory;
 
 
    private:
+    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                         Color         us) const {
+        return correctionHistory[key & sizeMinus1][us];
+    }
+
     size_t sizeMinus1, pawnHistSizeMinus1;
 };
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,13 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(std::size_t x) {
+    std::size_t n = 0;
+    while (x >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -603,7 +603,8 @@ void Search::Worker::clear() {
     captureHistory.fill(-678);
 
     // Each thread is responsible for clearing their part of shared history
-    sharedHistory.correctionHistory.clear_range(0, numaThreadIdx, numaTotal);
+    sharedHistory.correctionHistoryPawnMinor.clear_range(0, numaThreadIdx, numaTotal);
+    sharedHistory.correctionHistoryNonPawn.clear_range(0, numaThreadIdx, numaTotal);
     sharedHistory.pawnHistory.clear_range(-1238, numaThreadIdx, numaTotal);
 
     ttMoveHistory = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,10 +85,10 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
+    const int   pcv    = shared.pawn_correction_access(pos, us).read();
+    const int   micv   = shared.minor_correction_access(pos, us).read();
+    const int   wnpcv  = shared.nonpawn_correction_access<WHITE>(pos, us).read();
+    const int   bnpcv  = shared.nonpawn_correction_access<BLACK>(pos, us).read();
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
@@ -113,10 +113,10 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_access(pos, us) << bonus;
+    shared.minor_correction_access(pos, us) << bonus * 153 / 128;
+    shared.nonpawn_correction_access<WHITE>(pos, us) << bonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_access<BLACK>(pos, us) << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {


### PR DESCRIPTION
Stacked on #255 (`corrhist-tag5-spare-bits-refactor`), which is stacked on #254.

Addresses the 20% reads_coll_pct that nonpawnW and nonpawnB show at production-representative LTC SMP (20+0.2 x Threads=8) per the corrhist-occupancy instrumentation battery. Pawn and minor bundles are already at healthy collision rates (7.2% and 12.8%) so are left at 2^16.

## Change

- `CORRHIST_BASE_SIZE_NONPAWN = 2^17` — new constant, 2x the existing `CORRHIST_BASE_SIZE`.
- `CorrectionBundle` is split into `CorrectionBundlePawnMinor` (2 slots) and `CorrectionBundleNonPawn` (2 slots). Two separate `DynStats` replace the single unified correction-history table.
- Per-table thread cap auto-adjusts via the std::min composition from #255:
  - `CORRHIST_MAX_THREADS` (pawn+minor): 2^10 = 1024
  - `CORRHIST_MAX_THREADS_NONPAWN`: 2^8 = 256
- `clear()` in search.cpp clears both tables per numa partition.

## Memory delta

Per thread: `+512 KiB` vs #255 baseline (nonpawn table doubles its slot count but splits its per-entry size in half via the 2-slot bundle, so total nonpawn memory goes from `T x 256 KiB` to `T x 512 KiB`). At T=8: +4 MiB absolute.

## Bench

2727896 (was 2973580 on #255 / #254). The 8% drop is expected: larger nonpawn table changes index distribution so more slots return INIT (tag-miss-to-zero) or self, which shifts effective correction values enough to alter the depth/score path on bench positions. SPRT verdict is the relevant Elo signal, not bench.

## Test plan

- [x] PGO build succeeds.
- [x] Both corrhist tables clear correctly in `Search::Worker::clear()`.
- [x] Compile-time asserts (`static_assert` on per-table cap budgets) pass.
- [ ] Local cutechess gate: 5K games STC vs master.
- [ ] Fishtest STC SPRT (after #255 lands).
- [ ] Fishtest LTC SMP SPRT (after STC passes) — the key cell per instrumentation.