### PR TITLE
Tag shared corrhist slots with 5-bit discriminator (size_t / ilog2 / std::min cap)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,91 @@ enum StatsType {
     Captures
 };
 
+constexpr int           CORRHIST_VALUE_MIN      = -1024;
+constexpr int           CORRHIST_VALUE_MAX      = -CORRHIST_VALUE_MIN - 1;
+constexpr int           CORRHIST_INIT_VALUE     = 0;
+constexpr std::size_t   CORRHIST_SLOT_BITS      = sizeof(std::uint16_t) * 8;
+constexpr std::size_t   CORRHIST_VALUE_BITS     = ilog2(std::size_t(-CORRHIST_VALUE_MIN)) + 1;
+constexpr std::size_t   CORRHIST_TAG_BITS       = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr std::size_t   CORRHIST_KEY_BITS       = sizeof(std::uint64_t) * 8;
+constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT  = CORRHIST_KEY_BITS - CORRHIST_TAG_BITS;
+constexpr std::uint16_t CORRHIST_VALUE_MASK     = std::uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr std::uint16_t CORRHIST_VALUE_SIGN_BIT = std::uint16_t(1u << (CORRHIST_VALUE_BITS - 1u));
+constexpr std::uint16_t CORRHIST_TAG_RAW_MASK   = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS     = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MAX     = CORRHIST_DOMAIN_LOG2_PAWN;
+
+constexpr std::uint64_t CORRHIST_MAX_THREADS_STRUCT =
+  std::uint64_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
+constexpr std::uint64_t CORRHIST_MAX_THREADS_DATA =
+  std::uint64_t(1) << (CORRHIST_DOMAIN_LOG2_MAX - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS =
+  std::size_t(std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA));
+
+using CorrhistTag = std::uint8_t;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
+static_assert(CORRHIST_TAG_BITS >= 1);
+static_assert(CORRHIST_TAG_BITS <= sizeof(CorrhistTag) * 8);
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
+static_assert(CORRHIST_INIT_VALUE == 0);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_MAX);
+
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+    return t == 0 ? CorrhistTag(1) : t;
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::uint16_t> word{0};
+
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
+
+    int read(CorrhistTag tag) const {
+        const std::uint16_t w         = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const std::uint16_t low       = std::uint16_t(w & CORRHIST_VALUE_MASK);
+        const int           v = int(low ^ CORRHIST_VALUE_SIGN_BIT) - int(CORRHIST_VALUE_SIGN_BIT);
+        const std::int32_t  mask = -std::int32_t(storedTag != tag);
+        return v & ~mask;
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        constexpr int       D            = -CORRHIST_VALUE_MIN;
+        const int           clampedBonus = std::clamp(bonus, -D, D);
+        const std::uint16_t w            = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag    = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const std::uint16_t low          = std::uint16_t(w & CORRHIST_VALUE_MASK);
+        int                 v            = (storedTag == tag)
+                                           ? int(low ^ CORRHIST_VALUE_SIGN_BIT) - int(CORRHIST_VALUE_SIGN_BIT)
+                                           : CORRHIST_INIT_VALUE;
+        v                                = v + clampedBonus - v * std::abs(clampedBonus) / D;
+        v                                = std::clamp(v, CORRHIST_VALUE_MIN, CORRHIST_VALUE_MAX);
+        const std::uint16_t newWord =
+          (std::uint16_t(v) & CORRHIST_VALUE_MASK) | (std::uint16_t(tag) << CORRHIST_VALUE_BITS);
+        word.store(newWord, std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
+
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline int  read() const { return slot->read(tag); }
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+    inline sf_always_inline      operator int() const { return read(); }
+};
+
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
@@ -167,16 +252,21 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
+                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
+
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
 
     void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+        assert(val == 0);
+        (void) val;
+        pawn         = 0;
+        minor        = 0;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -221,7 +311,7 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(threadCount),
+        correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
@@ -260,11 +350,34 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
+    CorrhistAccess pawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.pawn_key();
+        return {&get_bundle(k, us).pawn, corrhist_tag_from(k)};
+    }
+    CorrhistAccess minor_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.minor_piece_key();
+        return {&get_bundle(k, us).minor, corrhist_tag_from(k)};
+    }
+    template<Color Us>
+    CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k      = pos.non_pawn_key(Us);
+        auto&               bundle = get_bundle(k, us);
+        if constexpr (Us == WHITE)
+            return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+        else
+            return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+    }
+
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
 
    private:
+    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                         Color         us) {
+        return correctionHistory[key & sizeMinus1][us];
+    }
+
     size_t sizeMinus1, pawnHistSizeMinus1;
 };
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,14 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(std::size_t x) {
+    assert(x >= 1);
+    std::size_t n = 0;
+    while (x >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,11 +84,11 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
-    const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
+    auto&       shared = w.sharedHistory;
+    const int   pcv    = shared.pawn_correction_access(pos, us).read();
+    const int   micv   = shared.minor_correction_access(pos, us).read();
+    const int   wnpcv  = shared.nonpawn_correction_access<WHITE>(pos, us).read();
+    const int   bnpcv  = shared.nonpawn_correction_access<BLACK>(pos, us).read();
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
@@ -113,10 +113,10 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_access(pos, us) << bonus;
+    shared.minor_correction_access(pos, us) << bonus * 153 / 128;
+    shared.nonpawn_correction_access<WHITE>(pos, us) << bonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_access<BLACK>(pos, us) << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {


### PR DESCRIPTION
Replaces closed #254 and #255 after the branch was renamed `corrhist-tag5-spare-bits-refactor` -> `corrhist-tags`.

Adds a 5-bit collision-discriminator tag to each shared correction-history slot, reusing the 5 spare bits in the `int16_t` entry. Memory-neutral vs master (same 16-bit atomic word, same `CORRHIST_BASE_SIZE = 2^16`). On tag mismatch reads return `CORRHIST_INIT_VALUE = 0`; writes evict the prior occupant and stamp the current tag. Filters silent collision aliasing in master's direct-indexed shared corrhist.

## Key design points

- **Tag bit layout:** 5-bit tag packed into the top of the 16-bit slot, 11-bit signed value in the low bits. Tag bits are derived (not hardcoded) from `sizeof(uint16_t)*8` and `CORRECTION_HISTORY_LIMIT`, so shrink/grow follow-ups re-derive automatically.
- **Tag source:** topmost 5 bits of the 64-bit key (`key >> 59`). Disjoint from any realistic low-bit index width used by `DynStats`-scaled corrhist.
- **Thread cap (auto-derived via `std::min`):**
  - `CORRHIST_MAX_THREADS_STRUCT` = `2^(KEY_BITS - TAG_BITS - log2(BASE_SIZE))` = `2^43` (structural bit-layout ceiling).
  - `CORRHIST_MAX_THREADS_DATA` = `2^(log2(reachable_domain) - log2(BASE_SIZE))` = `2^10 = 1024` (reachable pawn-key entropy, anchored on corrhist-occupancy instrumentation measurements).
  - `CORRHIST_MAX_THREADS` = `std::min` of the two.
- **Runtime consumption:** `SharedHistories(size_t threadCount)` clamps `correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS))`. No assert, no abort at high thread counts.
- **Utility helper `ilog2`:** moved to `misc.h` (Linux kernel naming, floor semantics, returns `std::size_t` for consistency with `sizeof`).
- **Types:** all bit-width constants are `std::size_t` to eliminate mixed-sign arithmetic with `sizeof` and shift amounts.

## Bench

2973580

## Supporting research

- `research/corrhist-occupancy-instrumentation.md` — 8-cell 26-game cutechess battery results measuring per-bundle reads_coll_pct, writes_coll_pct, and reachable `|A_true|` Bloom lower bounds. Data supports tag5 across all four bundles at LTC+SMP.
- `research/corrhist-tag-branch-plan.md` — decision tree, thread-count cap derivation (structural + data).

## Test plan

- [x] PGO build succeeds (`x86-64-avx512icl`).
- [x] Bench stable at 2973580 across refactor iterations.
- [x] Clang-format clean, no inline comments added.
- [x] 6 AI-agent review findings from the pre-rename PRs addressed (Gemini x3, Copilot x3).
- [x] CodeRabbit nitpick on `operator=` silent-discard addressed with `assert(v == 0)`.
- [ ] Fishtest STC SPRT.
- [ ] Fishtest LTC SPRT (if STC passes).
- [ ] Fishtest LTC SMP SPRT (the key cell per instrumentation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized correction history storage and access mechanisms for improved memory efficiency.
  * Enhanced position evaluation correction handling for better performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->