### PR TITLE
Split shared corrhist: grow nonpawn bundles to BASE_SIZE_NONPAWN = 2^17

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -35,17 +35,21 @@
 
 namespace Stockfish {
 
-constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
-constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
-constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
-constexpr int CORRECTION_HISTORY_LIMIT = 1024;
-constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+constexpr int PAWN_HISTORY_BASE_SIZE     = 8192;  // has to be a power of 2
+constexpr int UINT_16_HISTORY_SIZE       = std::numeric_limits<uint16_t>::max() + 1;
+constexpr int CORRHIST_BASE_SIZE         = UINT_16_HISTORY_SIZE;
+constexpr int CORRHIST_BASE_SIZE_NONPAWN = 1 << 17;
+constexpr int CORRECTION_HISTORY_LIMIT   = 1024;
+constexpr int LOW_PLY_HISTORY_SIZE       = 5;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((CORRHIST_BASE_SIZE_NONPAWN & (CORRHIST_BASE_SIZE_NONPAWN - 1)) == 0,
+              "CORRHIST_BASE_SIZE_NONPAWN has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -87,6 +91,104 @@ struct StatsEntry {
 enum StatsType {
     NoCaptures,
     Captures
+};
+
+constexpr int           CORRHIST_VALUE_MIN      = -1024;
+constexpr int           CORRHIST_VALUE_MAX      = -CORRHIST_VALUE_MIN - 1;
+constexpr int           CORRHIST_INIT_VALUE     = 0;
+constexpr std::size_t   CORRHIST_SLOT_BITS      = sizeof(std::uint16_t) * 8;
+constexpr std::size_t   CORRHIST_VALUE_BITS     = ilog2(std::size_t(-CORRHIST_VALUE_MIN)) + 1;
+constexpr std::size_t   CORRHIST_TAG_BITS       = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr std::size_t   CORRHIST_KEY_BITS       = sizeof(std::uint64_t) * 8;
+constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT  = CORRHIST_KEY_BITS - CORRHIST_TAG_BITS;
+constexpr std::uint16_t CORRHIST_VALUE_MASK     = std::uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr std::uint16_t CORRHIST_VALUE_SIGN_BIT = std::uint16_t(1u << (CORRHIST_VALUE_BITS - 1u));
+constexpr std::uint16_t CORRHIST_TAG_RAW_MASK   = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS_NONPAWN =
+  ilog2(std::size_t(CORRHIST_BASE_SIZE_NONPAWN));
+
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWNMINOR =
+  std::max(CORRHIST_DOMAIN_LOG2_PAWN, CORRHIST_DOMAIN_LOG2_MINOR);
+
+constexpr std::uint64_t CORRHIST_MAX_THREADS_STRUCT =
+  std::uint64_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
+constexpr std::uint64_t CORRHIST_MAX_THREADS_DATA =
+  std::uint64_t(1) << (CORRHIST_DOMAIN_LOG2_PAWNMINOR - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS =
+  std::size_t(std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA));
+
+constexpr std::uint64_t CORRHIST_MAX_THREADS_STRUCT_NONPAWN =
+  std::uint64_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS_NONPAWN);
+constexpr std::uint64_t CORRHIST_MAX_THREADS_DATA_NONPAWN =
+  std::uint64_t(1) << (CORRHIST_DOMAIN_LOG2_NONPAWN - CORRHIST_INDEX_BASE_BITS_NONPAWN);
+constexpr std::size_t CORRHIST_MAX_THREADS_NONPAWN =
+  std::size_t(std::min(CORRHIST_MAX_THREADS_STRUCT_NONPAWN, CORRHIST_MAX_THREADS_DATA_NONPAWN));
+
+using CorrhistTag = std::uint8_t;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
+static_assert(CORRHIST_TAG_BITS >= 1);
+static_assert(CORRHIST_TAG_BITS <= sizeof(CorrhistTag) * 8);
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
+static_assert(CORRHIST_INIT_VALUE == 0);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_PAWNMINOR);
+static_assert(CORRHIST_INDEX_BASE_BITS_NONPAWN <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS_NONPAWN <= CORRHIST_DOMAIN_LOG2_NONPAWN);
+
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+    return t == 0 ? CorrhistTag(1) : t;
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::uint16_t> word{0};
+
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
+
+    int read(CorrhistTag tag) const {
+        const std::uint16_t w         = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const std::uint16_t low       = std::uint16_t(w & CORRHIST_VALUE_MASK);
+        const int           v = int(low ^ CORRHIST_VALUE_SIGN_BIT) - int(CORRHIST_VALUE_SIGN_BIT);
+        const std::int32_t  mask = -std::int32_t(storedTag != tag);
+        return v & ~mask;
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        constexpr int       D            = -CORRHIST_VALUE_MIN;
+        const int           clampedBonus = std::clamp(bonus, -D, D);
+        const std::uint16_t w            = word.load(std::memory_order_relaxed);
+        const CorrhistTag   storedTag    = CorrhistTag(w >> CORRHIST_VALUE_BITS);
+        const std::uint16_t low          = std::uint16_t(w & CORRHIST_VALUE_MASK);
+        int                 v            = (storedTag == tag)
+                                           ? int(low ^ CORRHIST_VALUE_SIGN_BIT) - int(CORRHIST_VALUE_SIGN_BIT)
+                                           : CORRHIST_INIT_VALUE;
+        v                                = v + clampedBonus - v * std::abs(clampedBonus) / D;
+        v                                = std::clamp(v, CORRHIST_VALUE_MIN, CORRHIST_VALUE_MAX);
+        const std::uint16_t newWord =
+          (std::uint16_t(v) & CORRHIST_VALUE_MASK) | (std::uint16_t(tag) << CORRHIST_VALUE_BITS);
+        word.store(newWord, std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
+
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline int  read() const { return slot->read(tag); }
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+    inline sf_always_inline      operator int() const { return read(); }
 };
 
 template<typename T, int D, std::size_t... Sizes>
@@ -166,17 +268,32 @@ enum CorrHistType {
 };
 
 template<typename T, int D>
-struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+struct CorrectionBundlePawnMinor {
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT);
+
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
 
     void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+        assert(val == 0);
+        (void) val;
+        pawn  = 0;
+        minor = 0;
+    }
+};
+
+template<typename T, int D>
+struct CorrectionBundleNonPawn {
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT);
+
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
+
+    void operator=(T val) {
+        assert(val == 0);
+        (void) val;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -206,9 +323,13 @@ struct CorrHistTypedef<NonPawn> {
 
 }
 
-using UnifiedCorrectionHistory =
-  DynStats<MultiArray<CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
+using UnifiedCorrectionHistoryPawnMinor =
+  DynStats<MultiArray<CorrectionBundlePawnMinor<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
            CORRHIST_BASE_SIZE>;
+
+using UnifiedCorrectionHistoryNonPawn =
+  DynStats<MultiArray<CorrectionBundleNonPawn<std::int16_t, CORRECTION_HISTORY_LIMIT>, COLOR_NB>,
+           CORRHIST_BASE_SIZE_NONPAWN>;
 
 template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
@@ -221,14 +342,17 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(threadCount),
+        correctionHistoryPawnMinor(std::min(threadCount, CORRHIST_MAX_THREADS)),
+        correctionHistoryNonPawn(std::min(threadCount, CORRHIST_MAX_THREADS_NONPAWN)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
-        sizeMinus1         = correctionHistory.get_size() - 1;
-        pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+        sizeMinus1PawnMinor = correctionHistoryPawnMinor.get_size() - 1;
+        sizeMinus1NonPawn   = correctionHistoryNonPawn.get_size() - 1;
+        pawnHistSizeMinus1  = pawnHistory.get_size() - 1;
     }
 
-    size_t get_size() const { return sizeMinus1 + 1; }
+    size_t pawn_minor_size() const { return sizeMinus1PawnMinor + 1; }
+    size_t nonpawn_size() const { return sizeMinus1NonPawn + 1; }
 
     auto& pawn_entry(const Position& pos) {
         return pawnHistory[pos.pawn_key() & pawnHistSizeMinus1];
@@ -238,34 +362,54 @@ struct SharedHistories {
     }
 
     auto& pawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.pawn_key() & sizeMinus1PawnMinor];
     }
     const auto& pawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.pawn_key() & sizeMinus1PawnMinor];
     }
 
     auto& minor_piece_correction_entry(const Position& pos) {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.minor_piece_key() & sizeMinus1PawnMinor];
     }
     const auto& minor_piece_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+        return correctionHistoryPawnMinor[pos.minor_piece_key() & sizeMinus1PawnMinor];
     }
 
     template<Color c>
     auto& nonpawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+        return correctionHistoryNonPawn[pos.non_pawn_key(c) & sizeMinus1NonPawn];
     }
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+        return correctionHistoryNonPawn[pos.non_pawn_key(c) & sizeMinus1NonPawn];
     }
 
-    UnifiedCorrectionHistory correctionHistory;
-    PawnHistory              pawnHistory;
+    CorrhistAccess pawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.pawn_key();
+        return {&correctionHistoryPawnMinor[k & sizeMinus1PawnMinor][us].pawn,
+                corrhist_tag_from(k)};
+    }
+    CorrhistAccess minor_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.minor_piece_key();
+        return {&correctionHistoryPawnMinor[k & sizeMinus1PawnMinor][us].minor,
+                corrhist_tag_from(k)};
+    }
+    template<Color Us>
+    CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k      = pos.non_pawn_key(Us);
+        auto&               bundle = correctionHistoryNonPawn[k & sizeMinus1NonPawn][us];
+        if constexpr (Us == WHITE)
+            return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+        else
+            return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+    }
 
+    UnifiedCorrectionHistoryPawnMinor correctionHistoryPawnMinor;
+    UnifiedCorrectionHistoryNonPawn   correctionHistoryNonPawn;
+    PawnHistory                       pawnHistory;
 
    private:
-    size_t sizeMinus1, pawnHistSizeMinus1;
+    size_t sizeMinus1PawnMinor, sizeMinus1NonPawn, pawnHistSizeMinus1;
 };
 
 }  // namespace Stockfish

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,14 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(std::size_t x) {
+    assert(x >= 1);
+    std::size_t n = 0;
+    while (x >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,11 +84,11 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
-    const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
+    auto&       shared = w.sharedHistory;
+    const int   pcv    = shared.pawn_correction_access(pos, us).read();
+    const int   micv   = shared.minor_correction_access(pos, us).read();
+    const int   wnpcv  = shared.nonpawn_correction_access<WHITE>(pos, us).read();
+    const int   bnpcv  = shared.nonpawn_correction_access<BLACK>(pos, us).read();
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
@@ -113,10 +113,10 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_access(pos, us) << bonus;
+    shared.minor_correction_access(pos, us) << bonus * 153 / 128;
+    shared.nonpawn_correction_access<WHITE>(pos, us) << bonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_access<BLACK>(pos, us) << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {
@@ -603,7 +603,8 @@ void Search::Worker::clear() {
     captureHistory.fill(-678);
 
     // Each thread is responsible for clearing their part of shared history
-    sharedHistory.correctionHistory.clear_range(0, numaThreadIdx, numaTotal);
+    sharedHistory.correctionHistoryPawnMinor.clear_range(0, numaThreadIdx, numaTotal);
+    sharedHistory.correctionHistoryNonPawn.clear_range(0, numaThreadIdx, numaTotal);
     sharedHistory.pawnHistory.clear_range(-1238, numaThreadIdx, numaTotal);
 
     ttMoveHistory = 0;


### PR DESCRIPTION
Replaces closed #256 after the branch was renamed `corrhist-tag5-nonpawn-s17` -> `corrhist-tags-np-s17`. Stacked on #257 (`corrhist-tags`).

Addresses the 20% reads_coll_pct that nonpawnW and nonpawnB show at production-representative LTC SMP (20+0.2 x Threads=8) per the corrhist-occupancy instrumentation battery. Pawn and minor bundles sit at 7.2% and 12.8% reads_coll and are left at 2^16.

## Change

- `CORRHIST_BASE_SIZE_NONPAWN = 2^17` — new constant, 2x the existing `CORRHIST_BASE_SIZE`.
- `CorrectionBundle` is split into `CorrectionBundlePawnMinor` (2 slots) and `CorrectionBundleNonPawn` (2 slots). Two separate `DynStats` instances replace the single unified correction-history table.
- Per-table thread cap auto-derives via the `std::min` composition from #257:
  - `CORRHIST_MAX_THREADS` (pawn+minor): `2^10 = 1024`
  - `CORRHIST_MAX_THREADS_NONPAWN`: `2^8 = 256`
- `Search::Worker::clear()` clears both tables per numa partition.

## Memory delta

Per thread: +512 KiB vs #257 baseline. The nonpawn table doubles its slot count but splits into a 2-slot bundle (half the per-entry byte count), so total nonpawn memory goes from `T * 256 KiB` to `T * 512 KiB`. At T=8: +4 MiB absolute.

## Bench

2727896 (#257 is 2973580). The ~8% drop is expected: larger nonpawn table changes index distribution, shifting effective correction values enough to alter search-tree shape on bench positions. SPRT is the relevant Elo signal.

## Test plan

- [x] PGO build succeeds.
- [x] Both corrhist tables clear correctly in `clear()`.
- [x] Compile-time asserts on per-table bit budgets pass.
- [ ] Local cutechess STC gate.
- [ ] Fishtest STC SPRT (after #257 passes).
- [ ] Fishtest LTC SMP SPRT (the key cell per instrumentation).