### PR TITLE
LowPly hashed tagged table at 2^16 slots without tag-zero remap

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,18 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_LOW_PLY_BASE_SIZE & (HASHED_LOW_PLY_BASE_SIZE - 1)) == 0,
+              "HASHED_LOW_PLY_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -134,9 +141,81 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
+struct alignas(4) LowPlySlot {
+    std::uint32_t data;
+};
+static_assert(sizeof(LowPlySlot) == 4, "LowPlySlot must be 4 bytes");
+
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
+
+struct LowPly {
+    static constexpr int     VALUE_LIMIT = 7183;
+    static constexpr int16_t INIT        = 98;
+
+    static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
+    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
+                    && INIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::INIT must fit in int16_t");
+
+    static std::uint32_t input(int ply, std::uint16_t move_raw) {
+        assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
+        return (std::uint32_t(unsigned(ply)) << 16) | move_raw;
+    }
+    static std::uint64_t mix(std::uint32_t in) {
+        std::uint64_t k = in;
+        k *= 0x9E3779B97F4A7C15ULL;
+        k ^= k >> 32;
+        k *= 0xBF58476D1CE4E5B9ULL;
+        k ^= k >> 27;
+        return k;
+    }
+    static std::uint32_t idx_from(std::uint64_t h) {
+        return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
+    }
+    static std::uint16_t tag_from(std::uint64_t h) {
+        return std::uint16_t(h >> HASHED_LOW_PLY_INDEX_BITS);
+    }
+    static constexpr std::uint32_t pack(int v, std::uint16_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    static constexpr std::uint32_t empty_data() { return pack(INIT, 0); }
+    static constexpr int           extract(std::uint32_t data, std::uint16_t tag) {
+        const int          v    = int(std::int16_t(data & 0xFFFF));
+        const std::int32_t mask = -std::int32_t(std::uint16_t(data >> 16) != tag);
+        return (v & ~mask) | (int(INIT) & mask);
+    }
+
+    static int read(const LowPlyHistory& t, int ply, std::uint16_t move_raw) {
+        const std::uint64_t h   = mix(input(ply, move_raw));
+        const std::uint32_t idx = idx_from(h);
+        const std::uint16_t tag = tag_from(h);
+        return extract(t[idx].data, tag);
+    }
+
+    static void update(LowPlyHistory& t, int ply, std::uint16_t move_raw, int bonus) {
+        const std::uint64_t h            = mix(input(ply, move_raw));
+        const std::uint32_t idx          = idx_from(h);
+        const std::uint16_t tag          = tag_from(h);
+        const int           clampedBonus = std::clamp(bonus, -VALUE_LIMIT, VALUE_LIMIT);
+        LowPlySlot&         s            = t[idx];
+        int                 v            = extract(s.data, tag);
+        v += clampedBonus - v * std::abs(clampedBonus) / VALUE_LIMIT;
+        assert(std::abs(v) <= VALUE_LIMIT);
+        s.data = pack(v, tag);
+    }
+};
+
+static_assert(LowPly::extract(LowPly::empty_data(), 0) == LowPly::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(LowPly::extract(LowPly::empty_data(), 1) == LowPly::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip positive VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip negative VALUE_LIMIT");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * LowPly::read(*lowPlyHistory, ply, m.raw()) / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,7 +315,7 @@ bool Search::Worker::iterative_deepening() {
     int  searchAgainCounter = 0;
     bool uciPvSent          = false;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill({LowPly::empty_data()});
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1908,7 +1908,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        LowPly::update(workerThread.lowPlyHistory, ss->ply, move.raw(), bonus * 682 / 1024);
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
## Summary

Replace the hardcoded 5-row x 16384-square `LowPlyHistory` (5 MiB
per-thread) with a hashed table of 2^16 slots x 4 bytes = 256 KiB
per-thread, keyed by a splitmix64 mix of `(ply, move.raw())`. Each slot
holds a 16-bit signed value and a 16-bit tag in a single packed 32-bit
word. Cleared slots are initialized to `(tag=0, value=INIT)` so reads
on unwritten slots return INIT regardless of incoming tag, eliminating
the runtime cost of the previous `t == 0 ? 1 : t` remap.

This is the canonical single-commit form of the work that was
previously developed across `lowply-hashed-s16` and
`lowply-hashed-s16-fastpack`; the older stacked PR #259 has been
closed in favor of this one.

## Bench

3175410 (deterministic across PGO and non-PGO builds with this
layout).

## Why this layout

Per the natural-type-boundary rule, a 32-bit slot at 16/16 split
places the value's sign bit at bit 15 of the low half-word (the
int16 boundary) and the tag at bit 15 of the high half-word (the
uint16 boundary). Both fields extract via single narrow-load
microops with zero ALU. No other split width is cheaper. See
`research/tagged-slot-pack-unpack-codegen.md` for the full design
analysis.

## Why no tag-zero remap (Design C)

The cleared slot is initialized to `pack(INIT, 0)` =
`(storedTag=0, value=INIT)` rather than `(0, 0)`. With this fill,
both the match path (tag=0 query, storedTag=0) and the miss path
(tag != 0 query, storedTag=0) return INIT for unwritten slots. The
remap that previously forced `tag != 0` is therefore redundant and
removed. A `static_assert` on `empty_data()` enforces the encoding
invariant at compile time.

## Codegen savings (PGO, isolating just the remap drop)

Measured against the same hashed-tagged design with the remap
included, both built with
`make -j profile-build ARCH=x86-64-avx512icl COMP=mingw EXTRAPROFILEFLAGS=-fprofile-update=atomic`:

| function                                          | with remap | without remap | delta |
|---------------------------------------------------|----------:|--------------:|------:|
| update_quiet_histories (LowPly::update inlined)   |       369 |           368 |    -1 |
| MovePicker::next_move (LowPly::read inlined)      |      1733 |          1725 |    -8 |
| total ops/call cycle                              |      2102 |          2093 |    -9 |
| cmove count                                       |        26 |            24 |    -2 |

The two eliminated cmove instances are the remap (one cmove + its
companion mov 0x1 immediate-load) at each call site. The remap fired
on every LowPly read and write; movepick scoring calls
`LowPly::read` once per generated move, so the per-call savings
compound across move-list scoring loops.

## Correctness

Round-trip semantics:

1. cleared slot: `data = empty_data() = pack(INIT, 0)`.
2. read on cleared slot:
   - tag=0 query: storedTag(0) == queryTag(0) MATCH; returns stored
     value = INIT.
   - tag != 0 query: MISS; blend returns INIT.
3. read on written slot (any tag T_w):
   - matching query: returns stored value.
   - non-matching query: returns INIT.

False-positive rate analysis: with no remap,
`P(false match) = 1/2^16` per random pair, identical to the prior
remap's `(2^16+2)/2^32` to within 2^-32. Filtering quality unchanged.

## Test plan

- [x] PGO build passes with
      `EXTRAPROFILEFLAGS=-fprofile-update=atomic`
- [x] Bench 3175410, deterministic
- [x] Disassembly of `MovePicker::next_move` and
      `update_quiet_histories` shows -9 ops total and 2 fewer cmove
- [ ] Fishtest STC SPRT (10+0.1, normal bounds)

## Related work

- `research/tagged-slot-pack-unpack-codegen.md` for the full design
  space and codegen analysis.
- `diffs/lowply-hashed-tag-fastpack.md` for the per-branch summary
  and disassembly artifact pointers.