### PR TITLE
Tag shared corrhist slots with phase-separated callers

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,88 @@ enum StatsType {
     Captures
 };
 
+constexpr int           CORRHIST_VALUE_MIN      = -1024;
+constexpr int           CORRHIST_VALUE_MAX      = -CORRHIST_VALUE_MIN - 1;
+constexpr int           CORRHIST_INIT_VALUE     = 0;
+constexpr std::size_t   CORRHIST_SLOT_BITS      = sizeof(std::uint16_t) * 8;
+constexpr std::size_t   CORRHIST_VALUE_BITS     = ilog2(std::size_t(-CORRHIST_VALUE_MIN)) + 1;
+constexpr std::size_t   CORRHIST_TAG_BITS       = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr std::size_t   CORRHIST_KEY_BITS       = sizeof(std::uint64_t) * 8;
+constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT  = CORRHIST_KEY_BITS - CORRHIST_TAG_BITS;
+constexpr std::uint16_t CORRHIST_VALUE_MASK     = std::uint16_t((1u << CORRHIST_VALUE_BITS) - 1u);
+constexpr std::uint16_t CORRHIST_VALUE_SIGN_BIT = std::uint16_t(1u << (CORRHIST_VALUE_BITS - 1u));
+constexpr std::uint16_t CORRHIST_TAG_RAW_MASK   = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS     = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MAX     = CORRHIST_DOMAIN_LOG2_PAWN;
+
+constexpr std::uint64_t CORRHIST_MAX_THREADS_STRUCT =
+  std::uint64_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
+constexpr std::uint64_t CORRHIST_MAX_THREADS_DATA =
+  std::uint64_t(1) << (CORRHIST_DOMAIN_LOG2_MAX - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS =
+  std::size_t(std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA));
+
+using CorrhistTag = std::uint8_t;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
+static_assert(CORRHIST_TAG_BITS >= 1);
+static_assert(CORRHIST_TAG_BITS <= sizeof(CorrhistTag) * 8);
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
+static_assert(CORRHIST_INIT_VALUE == 0);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_MAX);
+
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    return CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::int16_t> word{0};
+
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
+
+    int read(CorrhistTag tag) const {
+        const int          u         = word.load(std::memory_order_relaxed);
+        const int          storedTag = u & int(CORRHIST_TAG_RAW_MASK);
+        const int          v         = u >> int(CORRHIST_TAG_BITS);
+        const std::int32_t mask      = -std::int32_t(storedTag != int(tag));
+        return v & ~mask;
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        assert((tag & ~CORRHIST_TAG_RAW_MASK) == 0);
+        constexpr int D = -CORRHIST_VALUE_MIN;
+        assert(std::abs(bonus) <= D);
+        const int u         = word.load(std::memory_order_relaxed);
+        const int storedTag = u & int(CORRHIST_TAG_RAW_MASK);
+        const int v_old     = u >> int(CORRHIST_TAG_BITS);
+        int       v         = (storedTag == int(tag)) ? v_old : CORRHIST_INIT_VALUE;
+        v                   = v + bonus - v * std::abs(bonus) / D;
+        v                   = std::min(v, CORRHIST_VALUE_MAX);
+        assert(v >= CORRHIST_VALUE_MIN);
+        const std::uint32_t newBits = (std::uint32_t(v) << CORRHIST_TAG_BITS) | std::uint32_t(tag);
+        word.store(std::int16_t(newBits), std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
+
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline int  read() const { return slot->read(tag); }
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+    inline sf_always_inline      operator int() const { return read(); }
+};
+
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
@@ -167,16 +249,21 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
+                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
+
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
 
     void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+        assert(val == 0);
+        (void) val;
+        pawn         = 0;
+        minor        = 0;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -221,7 +308,7 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(threadCount),
+        correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
@@ -260,11 +347,34 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
+    CorrhistAccess pawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.pawn_key();
+        return {&get_bundle(k, us).pawn, corrhist_tag_from(k)};
+    }
+    CorrhistAccess minor_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k = pos.minor_piece_key();
+        return {&get_bundle(k, us).minor, corrhist_tag_from(k)};
+    }
+    template<Color Us>
+    CorrhistAccess nonpawn_correction_access(const Position& pos, Color us) {
+        const std::uint64_t k      = pos.non_pawn_key(Us);
+        auto&               bundle = get_bundle(k, us);
+        if constexpr (Us == WHITE)
+            return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+        else
+            return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+    }
+
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
 
    private:
+    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                         Color         us) {
+        return correctionHistory[key & sizeMinus1][us];
+    }
+
     size_t sizeMinus1, pawnHistSizeMinus1;
 };
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,14 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(std::size_t x) {
+    assert(x >= 1);
+    std::size_t n = 0;
+    while (x >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,15 +84,22 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
-    const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
+    auto&       shared = w.sharedHistory;
+
+    const auto a_p = shared.pawn_correction_access(pos, us);
+    const auto a_m = shared.minor_correction_access(pos, us);
+    const auto a_w = shared.nonpawn_correction_access<WHITE>(pos, us);
+    const auto a_b = shared.nonpawn_correction_access<BLACK>(pos, us);
+
+    const int pcv   = a_p.read();
+    const int micv  = a_m.read();
+    const int wnpcv = a_w.read();
+    const int bnpcv = a_b.read();
+
+    const int cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+                : 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -113,10 +120,15 @@ void update_correction_history(const Position& pos,
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    const auto a_p = shared.pawn_correction_access(pos, us);
+    const auto a_m = shared.minor_correction_access(pos, us);
+    const auto a_w = shared.nonpawn_correction_access<WHITE>(pos, us);
+    const auto a_b = shared.nonpawn_correction_access<BLACK>(pos, us);
+
+    a_p << bonus;
+    a_m << bonus * 153 / 128;
+    a_w << bonus * nonPawnWeight / 128;
+    a_b << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {


### PR DESCRIPTION
## Summary

Adds a 5-bit tag to shared corrhist slots (pawn, minor, nonpawnW, nonpawnB)
to filter cross-position aliasing in the 11-bit value field, packed into a
single 16-bit atomic slot. Reads return INIT=0 on tag mismatch via a
branchless mask-blend; writes apply gravity then re-stamp the tag.

This is the canonical single-commit form combining what was previously
developed across `corrhist-tags` (hashed-tagged base) and a stacked
`corrhist-tags-fastpack` (codegen optimizations + phase separation).

## Optimizations applied

1. Value-high / tag-low layout: sign bit lands on the int16 boundary,
   `movsx` extracts value and `sar TAG_BITS` finishes the unpack in one
   ALU op.
2. `atomic<int16_t>` slot: load returns int16, so `int u =
   word.load(...)` sign-extends via `movsx` automatically.
3. No tag-zero remap: dropped because INIT=0 means cleared slots are
   bit-identical to mismatch-blend output regardless of incoming tag.
4. No pack-side tag mask: `corrhist_tag_from` already produces a
   masked tag. Pack uses `(uint32(v) << TAG_BITS) | tag` directly,
   guarded by `assert((tag & ~MASK) == 0)`.
5. `std::min` instead of `std::clamp`: lower bound is unreachable
   since `|v_new| <= D == -CORRHIST_VALUE_MIN`.
6. No internal bonus clamp in slot.update: matches contcorr-hashed-i19-lazy.
7. Phase separation in `correction_value` and `update_correction_history`:
   compute all 4 access objects in Phase 1, then dispatch via the proxy
   `<<` / `.read()` in Phase 2. Atomic ops issue back-to-back.

## Bench

3113651 (deterministic, PGO with `EXTRAPROFILEFLAGS=-fprofile-update=atomic`).

## PGO codegen savings (vs corrhist-tags)

| function                  | baseline | this PR | delta |
|---------------------------|---------:|--------:|------:|
| correction_value          |      119 |     108 |   -11 |
| update_correction_history |      258 |     216 |   -42 |
| branches in update        |        6 |       2 |    -4 |
| total ops/call            |      377 |     324 |  **-53** |

Per-bundle micro-optimizations contribute ~-37; phase separation
adds ~-16 by exposing the 4 atomic loads to the compiler back-to-back
(GCC treats atomic builtins as conservative scheduling barriers).

## Why the phase separation helps

GCC treats `__atomic_load_n` and `__atomic_store_n` as opaque
scheduling barriers in practice. Per-bundle source order serializes
each bundle's atomic chain. Phase-separated source lets the 4
addresses compute first, then the 4 atomic streams proceed in
adjacent cycles.

The matching pattern is established by contcorr-hashed-i19-lazy
(diffs/contcorr-hashed-i19-lazy.diff): build access proxies first,
then dispatch via `<<` / `.read()`.

## Test plan

- [x] PGO build passes with
      `EXTRAPROFILEFLAGS=-fprofile-update=atomic`
- [x] Bench 3113651, deterministic across 4 PGO retries
- [x] Disassembly shows -53 ops total and -4 branches in update
- [ ] Fishtest STC SPRT (10+0.1, normal bounds)

## Related work

- `research/tagged-slot-pack-unpack-codegen.md` for the full design
  space and codegen analysis (slot widths, layouts, sign-extension
  idioms, pack/unpack, hash construction, aliasing math, memory
  ordering, compiler scheduling).
- `diffs/corrhist-tags-fastpack.md` for the per-branch summary and
  disassembly artifact pointers.
- Prior baseline corrhist-tags: -0.45 Elo on Fishtest STC, CI
  [-2.52, +1.61], inconclusive STOPPED at 28K games.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized correction-history storage mechanism with improved data structure efficiency and tag-based invalidation.
  * Updated correction-history evaluation interface for enhanced access patterns.

* **Chores**
  * Added internal logarithm utility function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->