### PR TITLE
Move history prefetches out of do_move to caller

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -825,15 +825,8 @@ bool Position::gives_check(Move m) const {
 // Makes a move, and saves all information necessary
 // to a StateInfo object. The move is assumed to be legal. Pseudo-legal
 // moves should be filtered out before this function is called.
-// If a pointer to the TT table is passed, the entry for the new position
-// will be prefetched, and likewise for shared history.
-void Position::do_move(Move                      m,
-                       StateInfo&                newSt,
-                       bool                      givesCheck,
-                       DirtyPiece&               dp,
-                       DirtyThreats&             dts,
-                       const TranspositionTable* tt      = nullptr,
-                       const SharedHistories*    history = nullptr) {
+void Position::do_move(
+  Move m, StateInfo& newSt, bool givesCheck, DirtyPiece& dp, DirtyThreats& dts) {
 
     assert(m.is_ok());
     assert(&newSt != st);
@@ -1037,17 +1030,6 @@ void Position::do_move(Move                      m,
 
     // Update the key with the final value
     st->key = k;
-    if (tt)
-        prefetch(tt->first_entry(key()));
-
-    if (history)
-    {
-        prefetch(&history->pawn_entry(*this)[pc][to]);
-        prefetch(&history->pawn_correction_entry(*this));
-        prefetch(&history->minor_piece_correction_entry(*this));
-        prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
-        prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
-    }
 
     // Set capture piece
     st->capturedPiece = captured;

--- a/src/position.h
+++ b/src/position.h
@@ -34,9 +34,6 @@
 
 namespace Stockfish {
 
-class TranspositionTable;
-struct SharedHistories;
-
 // StateInfo struct stores information needed to restore a Position object to
 // its previous state when we retract a move. Whenever a move is made on the
 // board (by calling Position::do_move), a StateInfo object must be passed.
@@ -142,14 +139,8 @@ class Position {
     Piece captured_piece() const;
 
     // Doing and undoing moves
-    void do_move(Move m, StateInfo& newSt, const TranspositionTable* tt);
-    void do_move(Move                      m,
-                 StateInfo&                newSt,
-                 bool                      givesCheck,
-                 DirtyPiece&               dp,
-                 DirtyThreats&             dts,
-                 const TranspositionTable* tt,
-                 const SharedHistories*    worker);
+    void do_move(Move m, StateInfo& newSt);
+    void do_move(Move m, StateInfo& newSt, bool givesCheck, DirtyPiece& dp, DirtyThreats& dts);
     void undo_move(Move m);
     void do_null_move(StateInfo& newSt);
     void undo_null_move();
@@ -410,9 +401,9 @@ inline void Position::swap_piece(Square s, Piece pc, DirtyThreats* const dts) {
         update_piece_threats<true, false>(pc, s, dts);
 }
 
-inline void Position::do_move(Move m, StateInfo& newSt, const TranspositionTable* tt = nullptr) {
+inline void Position::do_move(Move m, StateInfo& newSt) {
     new (&scratch_dts) DirtyThreats;
-    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr);
+    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts);
 }
 
 inline StateInfo* Position::state() const { return st; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -570,7 +570,14 @@ void Search::Worker::do_move(
     nodes.store(nodes.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
 
     auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
-    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory);
+    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats);
+
+    prefetch(tt.first_entry(pos.key()));
+    prefetch(&sharedHistory.pawn_entry(pos)[dirtyPiece.pc][move.to_sq()]);
+    prefetch(&sharedHistory.pawn_correction_entry(pos));
+    prefetch(&sharedHistory.minor_piece_correction_entry(pos));
+    prefetch(&sharedHistory.nonpawn_correction_entry<WHITE>(pos));
+    prefetch(&sharedHistory.nonpawn_correction_entry<BLACK>(pos));
 
     if (ss != nullptr)
     {
@@ -2194,7 +2201,7 @@ bool RootMove::extract_ponder_from_tt(const TranspositionTable& tt, Position& po
     assert(pv.size() == 1 && pv[0] != Move::none());
 
     StateInfo st;
-    pos.do_move(pv[0], st, &tt);
+    pos.do_move(pv[0], st);
 
     if (!pos.is_draw(1))
     {


### PR DESCRIPTION
Moves the six history prefetches (TT first_entry, pawn_entry, four shared corrhist) out of the Position::do_move tail and into the Search::Worker::do_move caller. Drops both pointer parameters (TranspositionTable*, SharedHistories*) from the core do_move signature, removing the two unconditional-in-the-hot-path if (tt) / if (history) branches. Cold callers (perft, syzygy, engine setup, RootMove::extract_ponder_from_tt) no longer emit any prefetches; the prefetch sled is now caller code, not do_move code. No dummy allocations, no template specialization.

Disassembly (avx512icl, GCC 15.2.0 PGO):
- Position::do_move core: -56 instructions, -2 conditional jumps, all 6 prefetcht0 removed.
- Worker::do_move: +46 instructions, +6 prefetcht0 (the 6 moved here).
- search<NonPV>: -43 instructions net.

Lead time before child correction_value: ~150-440 cycles (master ~200-500), well above L3-to-L1 fill (~40-60 cycles).

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal move execution API and reorganized cache prefetching logic to improve code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->