### PR TITLE
Restore tag-zero remap on corrhist tagged slots

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -89,6 +89,97 @@ enum StatsType {
     Captures
 };
 
+constexpr int           CORRHIST_VALUE_MIN     = -1024;
+constexpr int           CORRHIST_VALUE_MAX     = -CORRHIST_VALUE_MIN - 1;
+constexpr int           CORRHIST_INIT_VALUE    = 0;
+constexpr std::size_t   CORRHIST_SLOT_BITS     = sizeof(std::uint16_t) * 8;
+constexpr std::size_t   CORRHIST_VALUE_BITS    = ilog2(std::size_t(-CORRHIST_VALUE_MIN)) + 1;
+constexpr std::size_t   CORRHIST_TAG_BITS      = CORRHIST_SLOT_BITS - CORRHIST_VALUE_BITS;
+constexpr std::size_t   CORRHIST_KEY_BITS      = sizeof(std::uint64_t) * 8;
+constexpr std::size_t   CORRHIST_TAG_KEY_SHIFT = CORRHIST_KEY_BITS - CORRHIST_TAG_BITS;
+constexpr std::uint16_t CORRHIST_TAG_RAW_MASK  = std::uint16_t((1u << CORRHIST_TAG_BITS) - 1u);
+
+constexpr std::size_t CORRHIST_INDEX_BASE_BITS     = ilog2(std::size_t(CORRHIST_BASE_SIZE));
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_PAWN    = 26;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MINOR   = 23;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_NONPAWN = 25;
+constexpr std::size_t CORRHIST_DOMAIN_LOG2_MAX     = CORRHIST_DOMAIN_LOG2_PAWN;
+
+constexpr std::uint64_t CORRHIST_MAX_THREADS_STRUCT =
+  std::uint64_t(1) << (CORRHIST_TAG_KEY_SHIFT - CORRHIST_INDEX_BASE_BITS);
+constexpr std::uint64_t CORRHIST_MAX_THREADS_DATA =
+  std::uint64_t(1) << (CORRHIST_DOMAIN_LOG2_MAX - CORRHIST_INDEX_BASE_BITS);
+constexpr std::size_t CORRHIST_MAX_THREADS =
+  std::size_t(std::min(CORRHIST_MAX_THREADS_STRUCT, CORRHIST_MAX_THREADS_DATA));
+
+using CorrhistTag = std::uint8_t;
+
+static_assert(CORRHIST_VALUE_BITS + CORRHIST_TAG_BITS == CORRHIST_SLOT_BITS);
+static_assert(CORRHIST_TAG_BITS >= 1);
+static_assert(CORRHIST_TAG_BITS <= sizeof(CorrhistTag) * 8);
+static_assert(-CORRHIST_VALUE_MIN == CORRECTION_HISTORY_LIMIT);
+static_assert(CORRHIST_INIT_VALUE == 0);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_TAG_KEY_SHIFT);
+static_assert(CORRHIST_INDEX_BASE_BITS <= CORRHIST_DOMAIN_LOG2_MAX);
+
+inline CorrhistTag corrhist_tag_from(std::uint64_t key) {
+    const CorrhistTag t = CorrhistTag((key >> CORRHIST_TAG_KEY_SHIFT) & CORRHIST_TAG_RAW_MASK);
+    return t == 0 ? CorrhistTag(1) : t;
+}
+
+struct alignas(2) CorrhistTaggedSlot {
+    std::atomic<std::int16_t> word{0};
+
+    void operator=(int v) {
+        assert(v == 0);
+        (void) v;
+        word.store(0, std::memory_order_relaxed);
+    }
+
+    int read(CorrhistTag tag) const {
+        const int u = word.load(std::memory_order_relaxed);
+        return (u & CORRHIST_TAG_RAW_MASK) == int(tag) ? u >> CORRHIST_TAG_BITS : 0;
+    }
+
+    inline sf_always_inline void update(CorrhistTag tag, int bonus) {
+        assert((tag & ~CORRHIST_TAG_RAW_MASK) == 0);
+        constexpr int D = -CORRHIST_VALUE_MIN;
+        assert(std::abs(bonus) <= D);
+        int v = read(tag);
+        v     = v + bonus - v * std::abs(bonus) / D;
+        v     = std::min(v, CORRHIST_VALUE_MAX);
+        assert(v >= CORRHIST_VALUE_MIN);
+        word.store(std::int16_t((std::uint32_t(v) << CORRHIST_TAG_BITS) | std::uint32_t(tag)),
+                   std::memory_order_relaxed);
+    }
+};
+static_assert(sizeof(CorrhistTaggedSlot) == 2);
+
+struct CorrhistReadAccess {
+    const CorrhistTaggedSlot* slot;
+    CorrhistTag               tag;
+
+    inline sf_always_inline int read() const { return slot->read(tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+
+    static CorrhistReadAccess pawn(const struct SharedHistories& sh, const Position& pos);
+    static CorrhistReadAccess minor(const struct SharedHistories& sh, const Position& pos);
+    template<Color Us>
+    static CorrhistReadAccess nonpawn(const struct SharedHistories& sh, const Position& pos);
+};
+
+struct CorrhistAccess {
+    CorrhistTaggedSlot* slot;
+    CorrhistTag         tag;
+
+    inline sf_always_inline void operator<<(int bonus) const { slot->update(tag, bonus); }
+
+    static CorrhistAccess pawn(struct SharedHistories& sh, const Position& pos);
+    static CorrhistAccess minor(struct SharedHistories& sh, const Position& pos);
+    template<Color Us>
+    static CorrhistAccess nonpawn(struct SharedHistories& sh, const Position& pos);
+};
+
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 
@@ -167,16 +258,21 @@ enum CorrHistType {
 
 template<typename T, int D>
 struct CorrectionBundle {
-    StatsEntry<T, D, true> pawn;
-    StatsEntry<T, D, true> minor;
-    StatsEntry<T, D, true> nonPawnWhite;
-    StatsEntry<T, D, true> nonPawnBlack;
+    static_assert(std::is_same_v<T, std::int16_t> && D == CORRECTION_HISTORY_LIMIT,
+                  "Tagged CorrectionBundle supports only int16_t and CORRECTION_HISTORY_LIMIT");
+
+    CorrhistTaggedSlot pawn;
+    CorrhistTaggedSlot minor;
+    CorrhistTaggedSlot nonPawnWhite;
+    CorrhistTaggedSlot nonPawnBlack;
 
     void operator=(T val) {
-        pawn         = val;
-        minor        = val;
-        nonPawnWhite = val;
-        nonPawnBlack = val;
+        assert(val == 0);
+        (void) val;
+        pawn         = 0;
+        minor        = 0;
+        nonPawnWhite = 0;
+        nonPawnBlack = 0;
     }
 };
 
@@ -221,7 +317,7 @@ using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 // the indexing more efficient.
 struct SharedHistories {
     SharedHistories(size_t threadCount) :
-        correctionHistory(threadCount),
+        correctionHistory(std::min(threadCount, CORRHIST_MAX_THREADS)),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
@@ -237,36 +333,59 @@ struct SharedHistories {
         return pawnHistory[pos.pawn_key() & pawnHistSizeMinus1];
     }
 
-    auto& pawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
-    }
-    const auto& pawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.pawn_key() & sizeMinus1];
-    }
-
-    auto& minor_piece_correction_entry(const Position& pos) {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
-    }
-    const auto& minor_piece_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
-    }
-
-    template<Color c>
-    auto& nonpawn_correction_entry(const Position& pos) {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
-    }
-    template<Color c>
-    const auto& nonpawn_correction_entry(const Position& pos) const {
-        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
-    }
-
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                         Color         us) {
+        return correctionHistory[key & sizeMinus1][us];
+    }
+    const CorrectionBundle<std::int16_t, CORRECTION_HISTORY_LIMIT>& get_bundle(std::uint64_t key,
+                                                                               Color us) const {
+        return correctionHistory[key & sizeMinus1][us];
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;
 };
+
+inline CorrhistReadAccess CorrhistReadAccess::pawn(const SharedHistories& sh, const Position& pos) {
+    const auto k = pos.pawn_key();
+    return {&sh.get_bundle(k, pos.side_to_move()).pawn, corrhist_tag_from(k)};
+}
+inline CorrhistReadAccess CorrhistReadAccess::minor(const SharedHistories& sh,
+                                                    const Position&        pos) {
+    const auto k = pos.minor_piece_key();
+    return {&sh.get_bundle(k, pos.side_to_move()).minor, corrhist_tag_from(k)};
+}
+template<Color Us>
+inline CorrhistReadAccess CorrhistReadAccess::nonpawn(const SharedHistories& sh,
+                                                      const Position&        pos) {
+    const auto  k      = pos.non_pawn_key(Us);
+    const auto& bundle = sh.get_bundle(k, pos.side_to_move());
+    if constexpr (Us == WHITE)
+        return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+    else
+        return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+}
+
+inline CorrhistAccess CorrhistAccess::pawn(SharedHistories& sh, const Position& pos) {
+    const auto k = pos.pawn_key();
+    return {&sh.get_bundle(k, pos.side_to_move()).pawn, corrhist_tag_from(k)};
+}
+inline CorrhistAccess CorrhistAccess::minor(SharedHistories& sh, const Position& pos) {
+    const auto k = pos.minor_piece_key();
+    return {&sh.get_bundle(k, pos.side_to_move()).minor, corrhist_tag_from(k)};
+}
+template<Color Us>
+inline CorrhistAccess CorrhistAccess::nonpawn(SharedHistories& sh, const Position& pos) {
+    const auto k      = pos.non_pawn_key(Us);
+    auto&      bundle = sh.get_bundle(k, pos.side_to_move());
+    if constexpr (Us == WHITE)
+        return {&bundle.nonPawnWhite, corrhist_tag_from(k)};
+    else
+        return {&bundle.nonPawnBlack, corrhist_tag_from(k)};
+}
 
 }  // namespace Stockfish
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,15 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(const std::size_t x) {
+    assert(x >= 1);
+    std::size_t y = x;
+    std::size_t n = 0;
+    while (y >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1043,10 +1043,10 @@ void Position::do_move(Move                      m,
     if (history)
     {
         prefetch(&history->pawn_entry(*this)[pc][to]);
-        prefetch(&history->pawn_correction_entry(*this));
-        prefetch(&history->minor_piece_correction_entry(*this));
-        prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
-        prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
+        prefetch(CorrhistReadAccess::pawn(*history, *this).slot);
+        prefetch(CorrhistReadAccess::minor(*history, *this).slot);
+        prefetch(CorrhistReadAccess::nonpawn<WHITE>(*history, *this).slot);
+        prefetch(CorrhistReadAccess::nonpawn<BLACK>(*history, *this).slot);
     }
 
     // Set capture piece

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,17 +82,23 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // optimized for require verifications at longer time controls
 
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
-    const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
-    const auto& shared = w.sharedHistory;
-    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
-    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
-    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
-    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
+    const auto m      = (ss - 1)->currentMove;
+    auto&      shared = w.sharedHistory;
+
+    const auto a_p = CorrhistReadAccess::pawn(shared, pos);
+    const auto a_m = CorrhistReadAccess::minor(shared, pos);
+    const auto a_w = CorrhistReadAccess::nonpawn<WHITE>(shared, pos);
+    const auto a_b = CorrhistReadAccess::nonpawn<BLACK>(shared, pos);
+
+    const int pcv   = a_p.read();
+    const int micv  = a_m.read();
+    const int wnpcv = a_w.read();
+    const int bnpcv = a_b.read();
+
+    const int cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+                : 8;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,16 +113,20 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
-    const Color us = pos.side_to_move();
+    const Move m = (ss - 1)->currentMove;
 
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
 
-    shared.pawn_correction_entry(pos)[us].pawn << bonus;
-    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 153 / 128;
-    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
-    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
+    const auto a_p = CorrhistAccess::pawn(shared, pos);
+    const auto a_m = CorrhistAccess::minor(shared, pos);
+    const auto a_w = CorrhistAccess::nonpawn<WHITE>(shared, pos);
+    const auto a_b = CorrhistAccess::nonpawn<BLACK>(shared, pos);
+
+    a_p << bonus;
+    a_m << bonus * 153 / 128;
+    a_w << bonus * nonPawnWeight / 128;
+    a_b << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {


### PR DESCRIPTION
Bench: 2973580

Restores the `t == 0 ? 1 : t` remap on `corrhist_tag_from` on top of the
`corrhist-tags-fastpack-v2` access-struct refactor. With the 5-bit tag,
raw-tag-0 inputs are about 3.13% of all queries; without the remap, a
tag-0 write produces a slot with storedTag=0 holding a learned value V,
and subsequent tag-0 reads from unrelated keys hashing to the same idx
return V as a tag match, destroying the cleared-slot sentinel.

Empirical Fishtest signal compared to the precursor:

- corrhist-tags (with remap, 5-bit tag): 34,560 games, -0.02 Elo, LLR -0.60.
- corrhist-tags-fastpack (no remap, this branch is its v2-with-remap counterpart): 14,336 games, -1.48 Elo, LLR -0.92, drifting away from neutral.

Gap is ~1.46 Elo across two polls in consistent direction; the codegen
savings from dropping the remap (-9 ops/call total) do not visibly offset
the lost cleared-slot semantics on Elo.

The remap is a one-line invariant that does not depend on hash output
distribution or future encoding changes. Codegen cost is ~2 cmove per
call site (one cmovne to remap from 0 to 1, plus the comparison).

Bit-identical to the corrhist-tags precursor at default depth 13, depth
20 (85,218,648), and depth 21 (110,454,891), confirming v2 fastpack
structural changes are search-tree-neutral and the remap restore
reproduces the precursor's search behaviour exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal correction history data structures and access patterns for improved memory efficiency.
  * Refined shared history management with updated accessor abstractions.
  * Added utility function to support revised internal data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->