### PR TITLE
Bulk-prefetch lowply slots at MovePicker score entry

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,20 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+constexpr int16_t  HASHED_LOW_PLY_INIT       = 98;
+constexpr uint32_t HASHED_LOW_PLY_EMPTY_DATA = uint32_t(uint16_t(HASHED_LOW_PLY_INIT));
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_LOW_PLY_BASE_SIZE & (HASHED_LOW_PLY_BASE_SIZE - 1)) == 0,
+              "HASHED_LOW_PLY_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -134,9 +143,104 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
+struct alignas(4) LowPlySlot {
+    std::uint32_t data{HASHED_LOW_PLY_EMPTY_DATA};
+};
+static_assert(sizeof(LowPlySlot) == 4, "LowPlySlot must be 4 bytes");
+static_assert(LowPlySlot{}.data == HASHED_LOW_PLY_EMPTY_DATA,
+              "Default-constructed LowPlySlot must hold HASHED_LOW_PLY_EMPTY_DATA");
+
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
+
+struct LowPly {
+    static constexpr int     VALUE_LIMIT = 7183;
+    static constexpr int16_t INIT        = HASHED_LOW_PLY_INIT;
+
+    static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
+    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
+                    && INIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::INIT must fit in int16_t");
+
+    static std::uint32_t input(int ply, std::uint16_t move_raw) {
+        assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
+        return (std::uint32_t(unsigned(ply)) << 16) | move_raw;
+    }
+    static std::uint64_t mix(std::uint32_t in) {
+        std::uint64_t k = in;
+        k *= 0x9E3779B97F4A7C15ULL;
+        k ^= k >> 32;
+        k *= 0xBF58476D1CE4E5B9ULL;
+        k ^= k >> 27;
+        return k;
+    }
+    static std::uint32_t idx_from(std::uint64_t h) {
+        return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
+    }
+    static std::uint16_t tag_from(std::uint64_t h) {
+        const std::uint16_t t = std::uint16_t(h >> HASHED_LOW_PLY_INDEX_BITS);
+        return t == 0 ? std::uint16_t(1) : t;
+    }
+    static constexpr std::uint32_t pack(int v, std::uint16_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    static constexpr std::uint32_t empty_data() { return pack(INIT, 0); }
+    static constexpr int           extract(std::uint32_t data, std::uint16_t tag) {
+        const int          v    = int(std::int16_t(data & 0xFFFF));
+        const std::int32_t mask = -std::int32_t(std::uint16_t(data >> 16) != tag);
+        return (v & ~mask) | (int(INIT) & mask);
+    }
+};
+
+struct LowPlyReadAccess {
+    const LowPlySlot* slot;
+    std::uint16_t     tag;
+
+    inline sf_always_inline int read() const { return LowPly::extract(slot->data, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+
+    static LowPlyReadAccess access(const LowPlyHistory& t, int ply, std::uint16_t move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+struct LowPlyAccess {
+    LowPlySlot*   slot;
+    std::uint16_t tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
+        int       v            = LowPly::extract(slot->data, tag);
+        v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
+        assert(std::abs(v) <= LowPly::VALUE_LIMIT);
+        slot->data = LowPly::pack(v, tag);
+    }
+
+    static LowPlyAccess access(LowPlyHistory& t, int ply, std::uint16_t move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+static_assert(HASHED_LOW_PLY_EMPTY_DATA == LowPly::empty_data(),
+              "Namespace-scope HASHED_LOW_PLY_EMPTY_DATA must equal LowPly::empty_data()");
+static_assert(LowPlySlot{}.data == LowPly::empty_data(),
+              "Default-constructed LowPlySlot must hold empty_data so reads return INIT");
+static_assert(LowPly::extract(LowPlySlot{}.data, 0) == LowPly::INIT,
+              "Default LowPlySlot read with tag=0 must return INIT (match path on cleared slot)");
+static_assert(LowPly::extract(LowPlySlot{}.data, 1) == LowPly::INIT,
+              "Default LowPlySlot read with non-zero tag must return INIT (mismatch blend)");
+static_assert(LowPly::extract(LowPly::empty_data(), 0) == LowPly::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(LowPly::extract(LowPly::empty_data(), 1) == LowPly::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip positive VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip negative VALUE_LIMIT");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -139,6 +139,11 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         threatByLesser[KING]  = 0;
     }
 
+    if constexpr (Type == QUIETS)
+        if (ply < LOW_PLY_HISTORY_SIZE)
+            for (const auto& mv : ml)
+                prefetch(LowPlyReadAccess::access(*lowPlyHistory, ply, mv.raw()).slot);
+
     ExtMove* it = cur;
     for (auto move : ml)
     {
@@ -176,7 +181,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * LowPlyReadAccess::access(*lowPlyHistory, ply, m.raw()) / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,7 +315,10 @@ bool Search::Worker::iterative_deepening() {
     int  searchAgainCounter = 0;
     bool uciPvSent          = false;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill({LowPly::empty_data()});
+    assert(LowPly::extract(lowPlyHistory.front().data, 0) == LowPly::INIT);
+    assert(LowPly::extract(lowPlyHistory.front().data, 1) == LowPly::INIT);
+    assert(LowPly::extract(lowPlyHistory.back().data, 0) == LowPly::INIT);
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1908,7 +1911,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        LowPlyAccess::access(workerThread.lowPlyHistory, ss->ply, move.raw()) << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 3175410

Adds a bulk read-prefetch sweep at the entry to MovePicker::score<QUIETS> on top of lowply-hashed-tag-fastpack-v2-remap (PR #270 base, with the tag-zero remap restored). Before the main scoring loop iterates each move, sweep the move list once and call prefetch() on every move's lowply slot via the existing LowPlyReadAccess::access(...).slot helper. Default prefetch hint = PrefetchLoc::HIGH (T0/L1).

Sweep is gated by Type == QUIETS && ply < LOW_PLY_HISTORY_SIZE, matching the gate of the actual lowply read site, so the prefetch only runs when the read will actually happen.

Selected from an instrumented microbattery on lowply-hashed-tag-fastpack-v2-pf-instr covering 7 prefetch configurations (3 sites x 2 locality + baseline), measured at LTC 8T UHO via cycle-bracketed sampling of every lowply read and write:

| Variant | reads_dram_pct | writes_dram_pct | mean_game_s |
|---|---:|---:|---:|
| baseline | 7.733 | 5.969 | 67.00 |
| loopahead-high | 1.329 | 3.258 | 75.75 |
| loopahead-low | 1.572 | 2.525 | 62.75 |
| bulkpre-high (this PR) | 0.479 | 4.559 | 66.50 |
| bulkpre-low | 2.118 | 12.829 | 60.00 |
| write-high | 12.583 | 5.559 | 68.50 |
| write-low | 10.703 | 4.400 | 68.50 |

bulkpre-high cuts read DRAM% by ~16x (7.73 -> 0.48) at no NPS cost. Write-site arms regress reads. LOW-locality bulk corrupts writes. The loopahead variants pay a per-iteration prefetch instruction tax that erases their NPS budget. Reproducibility check (8 games STC 1T + 1 game STC 8T) confirms the read-side ranking is stable across cells.

Bench is bit-identical to the base (3,175,410): the prefetch is a hint that does not change search behaviour, only the cycles spent waiting for memory.

Mechanism: MovePicker::score<QUIETS> reads the lowply slot for each generated quiet move at ply 0..4. The slot address is hash-randomised which defeats the hardware prefetcher. The bulk prefetch issues ~30 prefetcht0 instructions at score entry, fitting all lowply slots for the move list into L1 before the inner loop iterates each move. ~30 cache lines fits comfortably in L1 without displacing the NNUE accumulator or main-history working set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the internal move history mechanism used during search for improved performance and reduced memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->