### PR TITLE
Relocate corrhist read prefetches to top of Search::Worker::search

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1041,13 +1041,7 @@ void Position::do_move(Move                      m,
         prefetch(tt->first_entry(key()));
 
     if (history)
-    {
         prefetch(&history->pawn_entry(*this)[pc][to]);
-        prefetch(&history->pawn_correction_entry(*this));
-        prefetch(&history->minor_piece_correction_entry(*this));
-        prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
-        prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
-    }
 
     // Set capture piece
     st->capturedPiece = captured;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -638,6 +638,14 @@ Value Search::Worker::search(
     if (depth <= 0)
         return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
 
+    {
+        const Color us = pos.side_to_move();
+        prefetch(&sharedHistory.pawn_correction_entry(pos)[us].pawn);
+        prefetch(&sharedHistory.minor_piece_correction_entry(pos)[us].minor);
+        prefetch(&sharedHistory.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite);
+        prefetch(&sharedHistory.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack);
+    }
+
     // Limit the depth if extensions made it too large
     depth = std::min(depth, MAX_PLY - 1);
 


### PR DESCRIPTION
Bench: 2723949

## Summary

Isolates the READ-relocation half of #276 (`corrhist-write-prefetch-master`).
Removes the 4 corrhist prefetches from `Position::do_move` and re-adds them
as 4 READ prefetches at the top of `Search::Worker::search` (after the
qsearch dive). The pawn_entry prefetch in `do_move` is unchanged. No WRITE
prefetches in `update_correction_history`, no `-mprfchw` Makefile patch.

## Why this branch exists

PR #276 bundles three independent mechanisms: (1) read-relocation,
(2) PREFETCHW write-ownership claim in `update_correction_history`,
(3) Makefile `-mprfchw` across 6 ARCH stanzas. If #276 shows positive Elo
we cannot tell whether the gain is from (1), (2), or both. This branch
isolates (1) on master so SPRT can attribute the read-relocation effect
cleanly.

The companion simplification branch `simplify-corrhist-prefetch` is
drifting toward FAIL (LLR -1.90 at 126K games, simplification bounds),
proving the do_move corrhist prefetches are load-bearing. The natural
follow-up question this branch answers is: is the prefetch itself the
value, or is the call site (do_move) the value? Same prefetches, different
placement.

## Verification

- 0 `prefetchw` instructions in the binary (pure read-only, no -mprfchw needed).
- 21 total `prefetch` instructions; the 4 corrhist reads at search-top emit
  cleanly without disturbing surrounding code.
- Bench-identical to master (2,723,949) — prefetches are hints.

## Files

- `src/position.cpp` -- 4 corrhist prefetches removed from `Position::do_move`.
- `src/search.cpp` -- 4 READ prefetches added at top of `Search::Worker::search`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory access patterns during move generation and search operations to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->