### PR TITLE
Lowply rolling K=2 prefetch with on-the-fly hash recompute

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,20 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+constexpr int16_t  HASHED_LOW_PLY_INIT       = 98;
+constexpr uint32_t HASHED_LOW_PLY_EMPTY_DATA = uint32_t(uint16_t(HASHED_LOW_PLY_INIT));
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_LOW_PLY_BASE_SIZE & (HASHED_LOW_PLY_BASE_SIZE - 1)) == 0,
+              "HASHED_LOW_PLY_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -134,9 +143,104 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
+struct alignas(4) LowPlySlot {
+    std::uint32_t data{HASHED_LOW_PLY_EMPTY_DATA};
+};
+static_assert(sizeof(LowPlySlot) == 4, "LowPlySlot must be 4 bytes");
+static_assert(LowPlySlot{}.data == HASHED_LOW_PLY_EMPTY_DATA,
+              "Default-constructed LowPlySlot must hold HASHED_LOW_PLY_EMPTY_DATA");
+
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
+
+struct LowPly {
+    static constexpr int     VALUE_LIMIT = 7183;
+    static constexpr int16_t INIT        = HASHED_LOW_PLY_INIT;
+
+    static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
+    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
+                    && INIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::INIT must fit in int16_t");
+
+    static std::uint32_t input(int ply, std::uint16_t move_raw) {
+        assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
+        return (std::uint32_t(unsigned(ply)) << 16) | move_raw;
+    }
+    static std::uint64_t mix(std::uint32_t in) {
+        std::uint64_t k = in;
+        k *= 0x9E3779B97F4A7C15ULL;
+        k ^= k >> 32;
+        k *= 0xBF58476D1CE4E5B9ULL;
+        k ^= k >> 27;
+        return k;
+    }
+    static std::uint32_t idx_from(std::uint64_t h) {
+        return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
+    }
+    static std::uint16_t tag_from(std::uint64_t h) {
+        const std::uint16_t t = std::uint16_t(h >> HASHED_LOW_PLY_INDEX_BITS);
+        return t == 0 ? std::uint16_t(1) : t;
+    }
+    static constexpr std::uint32_t pack(int v, std::uint16_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    static constexpr std::uint32_t empty_data() { return pack(INIT, 0); }
+    static constexpr int           extract(std::uint32_t data, std::uint16_t tag) {
+        const int          v    = int(std::int16_t(data & 0xFFFF));
+        const std::int32_t mask = -std::int32_t(std::uint16_t(data >> 16) != tag);
+        return (v & ~mask) | (int(INIT) & mask);
+    }
+};
+
+struct LowPlyReadAccess {
+    const LowPlySlot* slot;
+    std::uint16_t     tag;
+
+    inline sf_always_inline int read() const { return LowPly::extract(slot->data, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+
+    static LowPlyReadAccess access(const LowPlyHistory& t, int ply, std::uint16_t move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+struct LowPlyAccess {
+    LowPlySlot*   slot;
+    std::uint16_t tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
+        int       v            = LowPly::extract(slot->data, tag);
+        v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
+        assert(std::abs(v) <= LowPly::VALUE_LIMIT);
+        slot->data = LowPly::pack(v, tag);
+    }
+
+    static LowPlyAccess access(LowPlyHistory& t, int ply, std::uint16_t move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+static_assert(HASHED_LOW_PLY_EMPTY_DATA == LowPly::empty_data(),
+              "Namespace-scope HASHED_LOW_PLY_EMPTY_DATA must equal LowPly::empty_data()");
+static_assert(LowPlySlot{}.data == LowPly::empty_data(),
+              "Default-constructed LowPlySlot must hold empty_data so reads return INIT");
+static_assert(LowPly::extract(LowPlySlot{}.data, 0) == LowPly::INIT,
+              "Default LowPlySlot read with tag=0 must return INIT (match path on cleared slot)");
+static_assert(LowPly::extract(LowPlySlot{}.data, 1) == LowPly::INIT,
+              "Default LowPlySlot read with non-zero tag must return INIT (mismatch blend)");
+static_assert(LowPly::extract(LowPly::empty_data(), 0) == LowPly::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(LowPly::extract(LowPly::empty_data(), 1) == LowPly::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip positive VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip negative VALUE_LIMIT");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -139,9 +139,25 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         threatByLesser[KING]  = 0;
     }
 
+    constexpr size_t              prefetchLookahead = 2;
+    [[maybe_unused]] const size_t n                 = ml.size();
+    [[maybe_unused]] const Move*  mv                = ml.begin();
+
+    if constexpr (Type == QUIETS)
+        if (ply < LOW_PLY_HISTORY_SIZE)
+            for (size_t k = 0; k < prefetchLookahead && k < n; ++k)
+                prefetch(LowPlyReadAccess::access(*lowPlyHistory, ply, mv[k].raw()).slot);
+
     ExtMove* it = cur;
+    size_t   i  = 0;
     for (auto move : ml)
     {
+        if constexpr (Type == QUIETS)
+            if (ply < LOW_PLY_HISTORY_SIZE && i + prefetchLookahead < n)
+                prefetch(
+                  LowPlyReadAccess::access(*lowPlyHistory, ply, mv[i + prefetchLookahead].raw())
+                    .slot);
+
         ExtMove& m = *it++;
         m          = move;
 
@@ -176,7 +192,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value +=
+                  8 * LowPlyReadAccess::access(*lowPlyHistory, ply, m.raw()).read() / (1 + ply);
         }
 
         else  // Type == EVASIONS
@@ -186,6 +203,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             else
                 m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
         }
+
+        ++i;
     }
     return it;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,7 +315,7 @@ bool Search::Worker::iterative_deepening() {
     int  searchAgainCounter = 0;
     bool uciPvSent          = false;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill({LowPly::empty_data()});
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        LowPlyAccess::access(workerThread.lowPlyHistory, ss->ply, move.raw()) << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 3175410

## Summary

Rolling K=2 prefetch lookahead in MovePicker::score<QUIETS>() for the hashed lowply table, with on-the-fly hash recomputation at every prefetch and read site (NO cached LowPlyReadAccess array on the stack). Single squashed commit on top of current master that bundles the hashed lowply infrastructure with the prefetch addition.

## Algorithm

Two prefetch sites:

1. **Priming pre-loop**: before the scoring loop, iterate `k` from 0 to `min(prefetchLookahead, n)` and prefetch each move's lowply slot. Issues 2 prefetches when `n >= 2`.
2. **Rolling in-loop**: in the scoring-loop body, when `i + prefetchLookahead < n`, prefetch the slot for `mv[i+2].raw()`. Issues `n-2` prefetches over the full loop.

The `LowPlyReadAccess::access(...)` call at each site recomputes the splitmix64 hash. The same recomputation also happens at the read site `m.value += 8 * LowPlyReadAccess::access(...).read() / (1 + ply)`. Three independent hash computations per move (priming for first 2 moves, rolling for moves 0..n-3, read for every move).

## Tradeoff vs cached variants (PR #278 lowply-hashed-pf-pull3-derived)

- **No stack array**: saves ~4 KB stack (no `lpAccess[MAX_MOVES]` reservoir).
- **Pays ~28 cy/move** of additional hash recomputation (rolling-prefetch hash + read-site hash, not shared).
- For n=30 quiets that's ~840 cy extra per scoring call vs the cached variant.

## Disassembly verification

Built PGO and disassembled `MovePicker::next_move` (which inlines `score<QUIETS>` after LTO):

| Site | Source | Address | Instruction |
|---|---|---|---|
| Read site | `m.value += 8 * LowPlyReadAccess::access(...).read() / (1 + ply)` | line 1128 | `mov eax,DWORD PTR [r13+r11*4+0x0]` (no prefetch — direct demand load) |
| Rolling in-loop prefetch | inside scoring loop | line 1172 | `prefetcht0 BYTE PTR [r10+r11*4]` |
| Priming pre-loop prefetch | pre-loop k=0..1 | line 1551 | `prefetcht0 BYTE PTR [r13+rbx*4+0x0]` |

Total prefetch instructions in next_move: 2 PREFETCHT0 (T0/HIGH locality, default).

splitmix64 sequences: 3 (one per site — read, rolling prefetch, priming prefetch). Each ~14 cy.

Addressing mode `[base + idx*4]` with `*4` stride matches `sizeof(LowPlySlot) = 4 bytes`. ✓

## Bench

3,175,410 — matches `lowply-hashed-pf` family bit-identical (prefetches are CPU hints).

## Cycle ledger (n = 30, prefetchLookahead = 2)

Slot k prefetch-to-use gap (single-thread, uncontended):

| k | Issued at | Used at | Gap |
|---|---|---|---|
| 0 | priming iter 0 | scoring iter 0 | priming iter 1 + scoring loop entry ~30 cy |
| 1 | priming iter 1 | scoring iter 1 | scoring iter 0 body ~85 cy |
| 2..n-3 | scoring iter (k-2) | scoring iter k | 2L ~170 cy |
| n-2, n-1 | not prefetched | demand load | full latency |

## Files modified

- `src/history.h` — hashed lowply infrastructure (LowPlySlot, LowPlyHistory, LowPly struct, LowPlyReadAccess, LowPlyAccess).
- `src/movepick.cpp` — priming pre-loop + rolling in-loop prefetch + cached read site.
- `src/search.cpp` — `lowPlyHistory.fill({LowPly::empty_data()})` initialization + `LowPlyAccess::access(...)` write site.

## Cross-references

- `diffs/lowply-hashed-pf.md` — original bulk-prefetch variant (RUNNING Fishtest).
- `diffs/lowply-hashed-pf-pull3-derived.md` — PR #278 cached-access rolling variant (production candidate).

This branch is the no-cache alternative to PR #278; head-to-head Fishtest would settle whether the 4 KB stack savings outweigh the ~840 cy/call hash recomputation overhead.