### PR TITLE
Move corrhist prefetch out of do_move to read and write sites

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1040,13 +1040,7 @@ void Position::do_move(Move                      m,
         prefetch(tt->first_entry(key()));
 
     if (history)
-    {
         prefetch(&history->pawn_entry(*this)[pc][to]);
-        prefetch(&history->pawn_correction_entry(*this));
-        prefetch(&history->minor_piece_correction_entry(*this));
-        prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
-        prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
-    }
 
     // Set capture piece
     st->capturedPiece = captured;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,6 +155,13 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
 
 }  // namespace
 
+void Search::Worker::prefetch_correction_history(const Position& pos) const {
+    prefetch(&sharedHistory.pawn_correction_entry(pos));
+    prefetch(&sharedHistory.minor_piece_correction_entry(pos));
+    prefetch(&sharedHistory.nonpawn_correction_entry<WHITE>(pos));
+    prefetch(&sharedHistory.nonpawn_correction_entry<BLACK>(pos));
+}
+
 Search::Worker::Worker(SharedState&                    sharedState,
                        std::unique_ptr<ISearchManager> sm,
                        size_t                          threadId,
@@ -735,6 +742,8 @@ Value Search::Worker::search(
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
+
+    prefetch_correction_history(pos);
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
@@ -1497,6 +1506,12 @@ moves_loop:  // When in check, search starts here
     if (bestValue <= alpha)
         ss->ttPv = ss->ttPv || (ss - 1)->ttPv;
 
+    const bool corrHistGate = !ss->inCheck && !(bestMove && pos.capture(bestMove))
+                           && (bestValue > ss->staticEval) == bool(bestMove);
+
+    if (corrHistGate)
+        prefetch_correction_history(pos);
+
     // Write gathered information in transposition table. Note that the
     // static evaluation is saved as it was before correction history.
     if (!excludedMove && !(rootNode && pvIdx))
@@ -1509,8 +1524,7 @@ moves_loop:  // When in check, search starts here
 
     // Adjust correction history if the best move is not a capture
     // and the error direction matches whether we are above/below bounds.
-    if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
-        && (bestValue > ss->staticEval) == bool(bestMove))
+    if (corrHistGate)
     {
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
@@ -1574,6 +1588,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Step 2. Check for an immediate draw or maximum ply reached
     if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;
+
+    if (!ss->inCheck)
+        prefetch_correction_history(pos);
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 

--- a/src/search.h
+++ b/src/search.h
@@ -358,6 +358,8 @@ class Worker {
 
     int reduction(bool i, Depth d, int mn, int delta) const;
 
+    void prefetch_correction_history(const Position& pos) const;
+
     // Pointer to the search manager, only allowed to be called by the main thread
     SearchManager* main_manager() const {
         assert(threadIdx == 0);


### PR DESCRIPTION
## Summary

Move the four shared correction-history prefetches (pawn, minor-piece, nonpawn-WHITE, nonpawn-BLACK) out of `Position::do_move()` and into the read and write sites in `Search::Worker::search()` and `Search::Worker::qsearch()`. TT and pawn-entry prefetches remain in `Position::do_move`.

A `prefetch_correction_history()` member helper centralizes the four prefetches. Three call sites:

- search() Step 4 read: just before TT.probe (~30-100 cy lead time)
- search() write site: just after `ss->ttPv` update (~40-120 cy via TT writeback cover); same lambda `corrHistGate` reused at the original conditional below
- qsearch() read: hoisted past Step 2, gated on `!ss->inCheck` (~30-100 cy via TT.probe)

Bench is identical to master. Prefetches are CPU hints with no semantic effect.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized prefetch handling in search evaluation and position processing to improve memory access efficiency and enhance search performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->