### PR TITLE
Move pawn entry prefetch out of do_move to write site with hoisted gate

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1041,7 +1041,6 @@ void Position::do_move(Move                      m,
 
     if (history)
     {
-        prefetch(&history->pawn_entry(*this)[pc][to]);
         prefetch(&history->pawn_correction_entry(*this));
         prefetch(&history->minor_piece_correction_entry(*this));
         prefetch(&history->nonpawn_correction_entry<WHITE>(*this));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,6 +155,10 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
 
 }  // namespace
 
+void Search::Worker::prefetch_pawn_entry_for_prev(const Position& pos, Square prevSq) const {
+    prefetch(&sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq]);
+}
+
 Search::Worker::Worker(SharedState&                    sharedState,
                        std::unique_ptr<ISearchManager> sm,
                        size_t                          threadId,
@@ -729,9 +733,17 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    Square prevSq  = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
-    bestMove       = Move::none();
-    priorReduction = (ss - 1)->reduction;
+    Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
+
+    const auto prevQuietBonusGate = [&priorCapture, &prevSq] {
+        return !priorCapture && prevSq != SQ_NONE;
+    };
+
+    if (prevQuietBonusGate())
+        prefetch_pawn_entry_for_prev(pos, prevSq);
+
+    bestMove            = Move::none();
+    priorReduction      = (ss - 1)->reduction;
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
@@ -1458,7 +1470,7 @@ moves_loop:  // When in check, search starts here
     }
 
     // Bonus for prior quiet countermove that caused the fail low
-    else if (!priorCapture && prevSq != SQ_NONE)
+    else if (prevQuietBonusGate())
     {
         int bonusScale = -232;
         bonusScale -= (ss - 1)->statScore / 108;

--- a/src/search.h
+++ b/src/search.h
@@ -358,6 +358,8 @@ class Worker {
 
     int reduction(bool i, Depth d, int mn, int delta) const;
 
+    void prefetch_pawn_entry_for_prev(const Position& pos, Square prevSq) const;
+
     // Pointer to the search manager, only allowed to be called by the main thread
     SearchManager* main_manager() const {
         assert(threadIdx == 0);


### PR DESCRIPTION
## Summary

Move the `pawn_entry[piece(prevSq)][prevSq]` prefetch out of `Position::do_move()` and into `Search::Worker::search()` near the top of the function. The prefetch is gated by a lambda wrapping the existing condition for the prior-quiet-countermove fail-low bonus (`!priorCapture && prevSq != SQ_NONE`); the same lambda is reused at the consumer `else if` later in the function.

The prefetched cache line is consumed by the futility-bonus write (line 904) and the prior-quiet-countermove write (line 1481) - both index by `piece_on(prevSq)`. There is no clean read-side analog: MovePicker reads `pawn_entry` by each candidate move's `(pc, to)`, which targets different cache lines within the 2 KB bucket.

Lead time: thousands of cycles across the entire body of `search()`, far longer than any DRAM round-trip.

The four shared corrhist prefetches and the TT prefetch in `Position::do_move()` remain in place. Bench is identical to master.

Bench: 2723949