### PR TITLE
Move hashed contcorr prefetch out of do_move to read and write call sites

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,18 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_CONTCORR_INDEX_BITS = 17;
+constexpr size_t   HASHED_CONTCORR_BASE_SIZE  = size_t(1) << HASHED_CONTCORR_INDEX_BITS;
+constexpr uint32_t HASHED_CONTCORR_INDEX_MASK = uint32_t(HASHED_CONTCORR_BASE_SIZE - 1);
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_CONTCORR_BASE_SIZE & (HASHED_CONTCORR_BASE_SIZE - 1)) == 0,
+              "HASHED_CONTCORR_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -214,6 +221,92 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+struct alignas(2) HashedContCorrSlot {
+    using Tag = std::uint8_t;
+
+    static constexpr int     TAG_BITS = 5;
+    static constexpr Tag     TAG_MASK = Tag((1u << TAG_BITS) - 1);
+    static constexpr int16_t INIT     = 6;
+    static constexpr int16_t NOK      = 8;
+
+    static constexpr int WORD_BITS  = 16;
+    static constexpr int VALUE_BITS = WORD_BITS - TAG_BITS;
+    static constexpr int VALUE_MAX  = (1 << (VALUE_BITS - 1)) - 1;
+    static constexpr int VALUE_MIN  = -(1 << (VALUE_BITS - 1));
+    static_assert(VALUE_BITS == 11, "HashedContCorrSlot value field must be 11 bits");
+    static_assert(CORRECTION_HISTORY_LIMIT <= 1024,
+                  "value is an 11-bit saturated signed field; widen the field or "
+                  "lower CORRECTION_HISTORY_LIMIT if this grows");
+
+    std::uint16_t word;
+
+    static constexpr std::uint16_t pack(int v, Tag t) {
+        return std::uint16_t((std::uint32_t(v) << TAG_BITS) | std::uint32_t(t));
+    }
+    static constexpr std::uint16_t empty_data() { return pack(INIT, Tag(0)); }
+
+    static constexpr int extract(std::uint16_t w, Tag t) {
+        const int          u         = int(std::int16_t(w));
+        const int          storedTag = u & int(TAG_MASK);
+        const int          v         = u >> TAG_BITS;
+        const std::int32_t mask      = -std::int32_t(storedTag != int(t));
+        return (v & ~mask) | (int(INIT) & mask);
+    }
+
+    static int read(std::uint16_t w, Tag t) { return extract(w, t); }
+
+    static inline sf_always_inline void update(HashedContCorrSlot& s, Tag t, int b) {
+        assert((t & ~TAG_MASK) == 0);
+        assert(std::abs(b) <= CORRECTION_HISTORY_LIMIT);
+        const int u         = int(std::int16_t(s.word));
+        const int storedTag = u & int(TAG_MASK);
+        const int v_old     = u >> TAG_BITS;
+        int       v         = (storedTag == int(t)) ? v_old : int(INIT);
+        v                   = v + b - v * std::abs(b) / CORRECTION_HISTORY_LIMIT;
+        v                   = std::min(v, int(VALUE_MAX));
+        assert(VALUE_MIN <= v && v <= VALUE_MAX);
+        s.word = pack(v, t);
+    }
+};
+static_assert(sizeof(HashedContCorrSlot) == 2, "HashedContCorrSlot must be 2 bytes");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::empty_data(),
+                                          HashedContCorrSlot::Tag(0))
+                == HashedContCorrSlot::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::empty_data(),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::pack(HashedContCorrSlot::VALUE_MAX,
+                                                                   HashedContCorrSlot::Tag(1)),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::VALUE_MAX,
+              "pack/extract round-trip positive VALUE_MAX");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::pack(HashedContCorrSlot::VALUE_MIN,
+                                                                   HashedContCorrSlot::Tag(1)),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::VALUE_MIN,
+              "pack/extract round-trip negative VALUE_MIN");
+
+struct HashedContCorrReadAccess {
+    const HashedContCorrSlot* slot;
+    HashedContCorrSlot::Tag   tag;
+
+    inline sf_always_inline int read() const { return HashedContCorrSlot::read(slot->word, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+};
+
+struct HashedContCorrAccess {
+    HashedContCorrSlot*     slot;
+    HashedContCorrSlot::Tag tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        HashedContCorrSlot::update(*slot, tag, bonus);
+    }
+};
+
+using HashedContCorrHistory = std::array<HashedContCorrSlot, HASHED_CONTCORR_BASE_SIZE>;
 
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,18 +81,68 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// hashed continuation-correction hash. NO_PIECE paired with SQ_A1 is the canonical
+// zero sentinel used before the root.
+static_assert(unsigned(NO_PIECE) == 0 && unsigned(SQ_A1) == 0,
+              "contcorr zero sentinel assumes NO_PIECE on SQ_A1 encodes to 0");
+static_assert(unsigned(PIECE_NB) * unsigned(SQUARE_NB) <= (1u << 10),
+              "contcorr_index must fit in 10 bits");
+unsigned contcorr_index(Piece pc, Square sq) {
+    return unsigned(pc) * unsigned(SQUARE_NB) + unsigned(sq);
+}
+
+// 64-bit mixer producing both a table index and a verification tag from
+// two 10-bit contcorrIndex inputs.
+uint64_t contcorr_mix(uint32_t a, uint32_t b) {
+    uint64_t k = (uint64_t(a) << 10) | b;
+    k *= 0x9E3779B97F4A7C15ULL;
+    k ^= k >> 32;
+    k *= 0xBF58476D1CE4E5B9ULL;
+    k ^= k >> 27;
+    return k;
+}
+
+uint32_t contcorr_idx_from(uint64_t h) { return uint32_t(h) & HASHED_CONTCORR_INDEX_MASK; }
+
+HashedContCorrSlot::Tag contcorr_tag_from(uint64_t h) {
+    const HashedContCorrSlot::Tag t = HashedContCorrSlot::Tag(
+      uint32_t(h >> HASHED_CONTCORR_INDEX_BITS) & HashedContCorrSlot::TAG_MASK);
+    return t == 0 ? HashedContCorrSlot::Tag(1) : t;
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+
+    int        cntcv;
+    const Move m = (ss - 1)->currentMove;
+    if (m.is_ok())
+    {
+        const auto&  table = w.hashedContCorrHistory;
+        const Square to    = m.to_sq();
+        const Piece  pc    = pos.piece_on(to);
+
+        const auto contcorrIndex = contcorr_index(pc, to);
+
+        const auto hashA = contcorr_mix(contcorrIndex, (ss - 2)->contcorrIndex);
+        const auto hashB = contcorr_mix(contcorrIndex, (ss - 4)->contcorrIndex);
+        const auto idxA  = contcorr_idx_from(hashA);
+        const auto idxB  = contcorr_idx_from(hashB);
+        const auto tagA  = contcorr_tag_from(hashA);
+        const auto tagB  = contcorr_tag_from(hashB);
+
+        const HashedContCorrReadAccess accA{&table[idxA], tagA};
+        const HashedContCorrReadAccess accB{&table[idxB], tagB};
+
+        cntcv = accA.read() + accB.read();
+    }
+    else
+        cntcv = HashedContCorrSlot::NOK;
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,7 +157,6 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 187;
@@ -118,12 +167,27 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
+    const Move m = (ss - 1)->currentMove;
     if (m.is_ok())
     {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+        auto&        table = workerThread.hashedContCorrHistory;
+        const Square to    = m.to_sq();
+        const Piece  pc    = pos.piece_on(to);
+
+        const auto contcorrIndex = contcorr_index(pc, to);
+
+        const auto hashA = contcorr_mix(contcorrIndex, (ss - 2)->contcorrIndex);
+        const auto hashB = contcorr_mix(contcorrIndex, (ss - 4)->contcorrIndex);
+        const auto idxA  = contcorr_idx_from(hashA);
+        const auto idxB  = contcorr_idx_from(hashB);
+        const auto tagA  = contcorr_tag_from(hashA);
+        const auto tagB  = contcorr_tag_from(hashB);
+
+        HashedContCorrAccess accA{&table[idxA], tagA};
+        HashedContCorrAccess accB{&table[idxB], tagB};
+
+        accA << bonus * 126 / 128;
+        accB << bonus * 63 / 128;
     }
 }
 
@@ -154,6 +218,24 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
 }
 
 }  // namespace
+
+void Search::Worker::prefetch_hashed_contcorr_history(const Position&    pos,
+                                                      const Stack* const ss) const {
+    const Move m = (ss - 1)->currentMove;
+    if (!m.is_ok())
+        return;
+
+    const Square to = m.to_sq();
+
+    // Use the post-promotion piece from pos.piece_on so the prefetched slot matches
+    // the one used by correction_value and update_correction_history.
+    const Piece pc            = pos.piece_on(to);
+    const auto  contcorrIndex = contcorr_index(pc, to);
+    const auto  hashA         = contcorr_mix(contcorrIndex, (ss - 2)->contcorrIndex);
+    const auto  hashB         = contcorr_mix(contcorrIndex, (ss - 4)->contcorrIndex);
+    prefetch(&hashedContCorrHistory[contcorr_idx_from(hashA)]);
+    prefetch(&hashedContCorrHistory[contcorr_idx_from(hashB)]);
+}
 
 Search::Worker::Worker(SharedState&                    sharedState,
                        std::unique_ptr<ISearchManager> sm,
@@ -285,12 +367,13 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrIndex = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
-        (ss + i)->ply = i;
+        (ss + i)->ply = uint16_t(i);
 
     ss->pv = &pv;
 
@@ -596,16 +679,15 @@ void Search::Worker::do_move(
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+        ss->contcorrIndex = uint16_t(contcorr_index(dirtyPiece.pc, move.to_sq()));
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = 0;
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -627,9 +709,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    hashedContCorrHistory.fill(HashedContCorrSlot{HashedContCorrSlot::empty_data()});
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})
@@ -735,6 +815,8 @@ Value Search::Worker::search(
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
+
+    prefetch_hashed_contcorr_history(pos, ss);
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
@@ -1497,6 +1579,12 @@ moves_loop:  // When in check, search starts here
     if (bestValue <= alpha)
         ss->ttPv = ss->ttPv || (ss - 1)->ttPv;
 
+    const bool corrHistGate = !ss->inCheck && !(bestMove && pos.capture(bestMove))
+                           && (bestValue > ss->staticEval) == bool(bestMove);
+
+    if (corrHistGate)
+        prefetch_hashed_contcorr_history(pos, ss);
+
     // Write gathered information in transposition table. Note that the
     // static evaluation is saved as it was before correction history.
     if (!excludedMove && !(rootNode && pvIdx))
@@ -1509,8 +1597,7 @@ moves_loop:  // When in check, search starts here
 
     // Adjust correction history if the best move is not a capture
     // and the error direction matches whether we are above/below bounds.
-    if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
-        && (bestValue > ss->staticEval) == bool(bestMove))
+    if (corrHistGate)
     {
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth * (bestMove ? 12 : 17) / 128,
@@ -1574,6 +1661,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Step 2. Check for an immediate draw or maximum ply reached
     if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;
+
+    if (!ss->inCheck)
+        prefetch_hashed_contcorr_history(pos, ss);
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,21 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*        pv;
+    PieceToHistory* continuationHistory;
+    int             statScore;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    uint16_t        moveCount;
+    uint16_t        contcorrIndex;
+    int16_t         cutoffCnt;
+    int16_t         reduction;
+    uint16_t        ply;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
 };
 
 
@@ -331,9 +331,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
+    HashedContCorrHistory hashedContCorrHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;
@@ -357,6 +357,8 @@ class Worker {
     Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta);
 
     int reduction(bool i, Depth d, int mn, int delta) const;
+
+    void prefetch_hashed_contcorr_history(const Position& pos, const Stack* const ss) const;
 
     // Pointer to the search manager, only allowed to be called by the main thread
     SearchManager* main_manager() const {


### PR DESCRIPTION
## Summary

Hashed contcorr i17 prefetch relocated from `Worker::do_move` epilogue (PR #279 design) to three call sites in `Search::Worker::search()` and `Search::Worker::qsearch()`. Built on top of the i17 hashed contcorr base from `contcorr-hashed-i17-fastpack-remap`.

A new member helper `Worker::prefetch_hashed_contcorr_history(pos, ss)` computes the two slot hashes (`contcorr_mix` x2) and issues T0 read prefetches. Three call sites:

- **search() pre-Step-4 read** (just before TT.probe). Provably-not-wasted: `correction_value` (Step 5) runs unconditionally past Step 4 in `search()`. Lead time: TT.probe + entry into `correction_value` + 4 shared corrhist loads = ~60-200 cy.
- **search() write site** (post-`ttPv`-update, just before TT writeback). Gated by a `const bool corrHistGate` capturing `!ss->inCheck && !(bestMove && pos.capture(bestMove)) && (bestValue > ss->staticEval) == bool(bestMove)` -- the exact condition for `update_correction_history` below. Same bool reused at the consumer if so the gate is computed once. Lead time: TT writeback + 4 shared corrhist writes = ~80-250 cy.
- **qsearch() pre-Step-3 read** (just before TT.probe), gated on `!ss->inCheck`. Trades TT-cutoff waste (~30-50% of qsearch nodes) for additional lead time over the post-cutoff alternative.

The do_move-l2 epilogue prefetch from PR #279 is removed.

## Differences from PR #275 (in-function hoist)

PR #275 hoists the hash compute + prefetch to the top of `correction_value`; lead time is only the 4 shared corrhist loads (~30-100 cy) before the demand read. This branch moves the prefetch outside the function so TT.probe latency contributes to lead time.

## Differences from PR #279 (do_move-l2)

PR #279 places the prefetch in `Worker::do_move` epilogue. Long lead time but pays the ~22 cy hash compute on every do_move including TT-cutoff paths in qsearch. This branch eliminates the do_move-side prefetch and gates by call-site conditions.

## Codegen note

Earlier draft used `[&] { ... }` lambda for the write-site gate; objdump showed GCC compiled it as a separate function (`UlvE_clEv.isra.0`) called twice per node visit (~30-40 cy + 8 BTB entries per node). Reverted to `const bool` so the gate is evaluated inline once and reused with simple `test/jne` checks (~22-31 cy + 6 BTB entries).

## Files modified

- `src/history.h` (+93 lines from i17 base): hashed contcorr table infrastructure.
- `src/search.h` (i17 base + helper declaration): `Worker` field for the per-thread hashed table, `prefetch_hashed_contcorr_history` member declaration.
- `src/search.cpp`: i17 base machinery, member helper definition, three call sites with const-bool gate at the write site, do_move-l2 prefetch removed.

Bench: 2560635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuation correction history storage mechanism by replacing legacy 2D table approach with a more memory-efficient hashed structure.
  * Reduced state tracking overhead by using narrower fixed-width types and compact data representations.
  * Integrated prefetching optimization for improved cache performance in search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->