### PR TITLE
Bulk-prefetch lowply slots with LOW locality (T2)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,20 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+constexpr int16_t  HASHED_LOW_PLY_INIT       = 98;
+constexpr uint32_t HASHED_LOW_PLY_EMPTY_DATA = uint32_t(uint16_t(HASHED_LOW_PLY_INIT));
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_LOW_PLY_BASE_SIZE & (HASHED_LOW_PLY_BASE_SIZE - 1)) == 0,
+              "HASHED_LOW_PLY_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -134,9 +143,108 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
+struct alignas(4) LowPlySlot {
+    std::uint32_t data{HASHED_LOW_PLY_EMPTY_DATA};
+};
+static_assert(sizeof(LowPlySlot) == 4, "LowPlySlot must be 4 bytes");
+static_assert(LowPlySlot{}.data == HASHED_LOW_PLY_EMPTY_DATA,
+              "Default-constructed LowPlySlot must hold HASHED_LOW_PLY_EMPTY_DATA");
+
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
+
+struct LowPly {
+    static constexpr int     VALUE_LIMIT = 7183;
+    static constexpr int16_t INIT        = HASHED_LOW_PLY_INIT;
+
+    static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
+    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
+                    && INIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::INIT must fit in int16_t");
+
+    static inline sf_always_inline std::uint32_t input(int ply, std::uint16_t move_raw) {
+        assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
+        return (std::uint32_t(unsigned(ply)) << 16) | move_raw;
+    }
+    static inline sf_always_inline std::uint64_t mix(std::uint32_t in) {
+        std::uint64_t k = in;
+        k *= 0x9E3779B97F4A7C15ULL;
+        k ^= k >> 32;
+        k *= 0xBF58476D1CE4E5B9ULL;
+        k ^= k >> 27;
+        return k;
+    }
+    static inline sf_always_inline std::uint32_t idx_from(std::uint64_t h) {
+        return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
+    }
+    static inline sf_always_inline std::uint16_t tag_from(std::uint64_t h) {
+        const std::uint16_t t = std::uint16_t(h >> HASHED_LOW_PLY_INDEX_BITS);
+        return t == 0 ? std::uint16_t(1) : t;
+    }
+    static inline sf_always_inline constexpr std::uint32_t pack(int v, std::uint16_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    static inline sf_always_inline constexpr std::uint32_t empty_data() { return pack(INIT, 0); }
+    static inline sf_always_inline constexpr int extract(std::uint32_t data, std::uint16_t tag) {
+        const std::uint32_t v    = std::uint32_t(std::uint16_t(data & 0xFFFF));
+        const std::uint32_t mask = std::uint32_t(-std::int32_t(std::uint16_t(data >> 16) != tag));
+        return int(std::int16_t((v & ~mask) | (std::uint32_t(std::uint16_t(INIT)) & mask)));
+    }
+};
+
+struct LowPlyReadAccess {
+    const LowPlySlot* slot;
+    std::uint16_t     tag;
+
+    inline sf_always_inline int read() const { return LowPly::extract(slot->data, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+
+    static inline sf_always_inline LowPlyReadAccess access(const LowPlyHistory& t,
+                                                           int                  ply,
+                                                           std::uint16_t        move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+struct LowPlyAccess {
+    LowPlySlot*   slot;
+    std::uint16_t tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
+        int       v            = LowPly::extract(slot->data, tag);
+        v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
+        assert(std::abs(v) <= LowPly::VALUE_LIMIT);
+        slot->data = LowPly::pack(v, tag);
+    }
+
+    static inline sf_always_inline LowPlyAccess access(LowPlyHistory& t,
+                                                       int            ply,
+                                                       std::uint16_t  move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+static_assert(HASHED_LOW_PLY_EMPTY_DATA == LowPly::empty_data(),
+              "Namespace-scope HASHED_LOW_PLY_EMPTY_DATA must equal LowPly::empty_data()");
+static_assert(LowPlySlot{}.data == LowPly::empty_data(),
+              "Default-constructed LowPlySlot must hold empty_data so reads return INIT");
+static_assert(LowPly::extract(LowPlySlot{}.data, 0) == LowPly::INIT,
+              "Default LowPlySlot read with tag=0 must return INIT (match path on cleared slot)");
+static_assert(LowPly::extract(LowPlySlot{}.data, 1) == LowPly::INIT,
+              "Default LowPlySlot read with non-zero tag must return INIT (mismatch blend)");
+static_assert(LowPly::extract(LowPly::empty_data(), 0) == LowPly::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(LowPly::extract(LowPly::empty_data(), 1) == LowPly::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip positive VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+              "extract(pack(v, tag), tag) must round-trip negative VALUE_LIMIT");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -139,6 +139,12 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         threatByLesser[KING]  = 0;
     }
 
+    if constexpr (Type == QUIETS)
+        if (ply < LOW_PLY_HISTORY_SIZE)
+            for (const auto& mv : ml)
+                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(
+                  LowPlyReadAccess::access(*lowPlyHistory, ply, mv.raw()).slot);
+
     ExtMove* it = cur;
     for (auto move : ml)
     {
@@ -176,7 +182,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * LowPlyReadAccess::access(*lowPlyHistory, ply, m.raw()) / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,7 +315,7 @@ bool Search::Worker::iterative_deepening() {
     int  searchAgainCounter = 0;
     bool uciPvSent          = false;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill({LowPly::empty_data()});
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        LowPlyAccess::access(workerThread.lowPlyHistory, ss->ply, move.raw()) << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 3175410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal move history storage structure for improved memory efficiency and faster lookup during move evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->