### PR TITLE
Hashed lowply with 8-bit tag and 3-byte slot

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -162,13 +162,27 @@ static_assert(alignof(LowPlySlot) == 1, "LowPlySlot must be byte-aligned for 3-b
 static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
               "LowPlySlot 32-bit read/write path assumes little-endian byte order");
 
-// One trailing slot of pad: the read/write fast path issues a 32-bit
-// load (and store) that overlaps the next slot's first byte; at the
-// last valid index that byte must be in-bounds storage.
-using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE + 1>;
-static_assert(sizeof(LowPlyHistory) >= sizeof(LowPlySlot) * HASHED_LOW_PLY_BASE_SIZE + 1,
-              "LowPlyHistory storage must extend at least 1 byte beyond the last "
-              "valid slot for the 32-bit tail load/store at index BASE_SIZE-1");
+// LowPlyHistory wraps BASE_SIZE valid 3-byte slots plus 1 byte of
+// trailing pad: the read/write fast path issues a 32-bit load (and
+// store) that overlaps the next slot's first byte, and at the last
+// valid index that byte sits inside the trailing pad.
+struct LowPlyHistory {
+    std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE> data;
+    std::uint8_t                                     pad;
+
+    sf_always_inline constexpr LowPlySlot& operator[](std::size_t i) noexcept { return data[i]; }
+    sf_always_inline constexpr const LowPlySlot& operator[](std::size_t i) const noexcept {
+        return data[i];
+    }
+    sf_always_inline constexpr void fill(const LowPlySlot& v) noexcept {
+        data.fill(v);
+        pad = 0;
+    }
+};
+static_assert(sizeof(LowPlyHistory) == HASHED_LOW_PLY_BASE_SIZE * 3 + 1,
+              "LowPlyHistory must be exactly BASE_SIZE * 3 + 1 bytes "
+              "(BASE_SIZE 3-byte slots + 1 trailing pad byte for the "
+              "32-bit tail load/store at index BASE_SIZE-1)");
 
 // may_alias allows the compiler to type-pun a LowPlySlot through a
 // uint32_t pointer without violating strict aliasing.
@@ -242,10 +256,15 @@ struct LowPlyAccess {
         int           v            = LowPly::extract(raw, tag);
         const int     clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
         v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
+        // Pre-store bounds check: value to be assigned must fit within
+        // VALUE_LIMIT (and therefore within int16_t for packed storage).
         assert(std::abs(v) <= LowPly::VALUE_LIMIT);
         // Preserve the high 8 bits (next slot's first byte, or trailing
         // pad) and update the low 24 bits with the new (value, tag).
         *rawPtr = (raw & 0xFF000000u) | LowPly::pack(v, tag);
+        // Post-store round-trip: the slot now reads back the value we
+        // just wrote when queried with the same tag.
+        assert(LowPly::extract(*rawPtr, tag) == v);
     }
 
     static inline sf_always_inline LowPlyAccess access(LowPlyHistory& t,

--- a/src/history.h
+++ b/src/history.h
@@ -26,7 +26,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
-#include <cstring>
 #include <limits>
 #include <type_traits>  // IWYU pragma: keep
 
@@ -42,11 +41,11 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
-constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
-constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
-constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
-constexpr int16_t  HASHED_LOW_PLY_INIT       = 98;
-constexpr uint8_t  HASHED_LOW_PLY_EMPTY_TAG  = 0;
+constexpr int      HASHED_LOW_PLY_INDEX_BITS    = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE     = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK    = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+constexpr int16_t  HASHED_LOW_PLY_VALUE_DEFAULT = 98;
+constexpr uint8_t  HASHED_LOW_PLY_EMPTY_TAG     = 0;
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
@@ -144,47 +143,33 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
-// Slot is 3 bytes: int16_t value followed by uint8_t tag. The fast read
-// path issues a 4-byte load and unpacks; the trailing byte is the next
-// slot's first byte, or tail padding for the last valid slot.
+// LowPlyHistory is addressed by ply and move's from and to squares, used
+// to improve move ordering near the root
 struct __attribute__((packed)) LowPlySlot {
     std::int16_t value;
     std::uint8_t tag;
 
     constexpr LowPlySlot() noexcept :
-        value(HASHED_LOW_PLY_INIT),
+        value(HASHED_LOW_PLY_VALUE_DEFAULT),
         tag(HASHED_LOW_PLY_EMPTY_TAG) {}
     constexpr LowPlySlot(std::int16_t v, std::uint8_t t) noexcept :
         value(v),
         tag(t) {}
 };
 static_assert(sizeof(LowPlySlot) == 3, "LowPlySlot must be 3 bytes");
-static_assert(alignof(LowPlySlot) == 1, "LowPlySlot must be byte-aligned for 3-byte stride");
 
-// One trailing slot beyond HASHED_LOW_PLY_BASE_SIZE provides padding so
-// that a 4-byte load at the last valid index does not overflow the
-// storage. With sizeof(LowPlySlot)==3, the 4-byte load at index
-// BASE_SIZE-1 reads bytes [3*(BASE_SIZE-1), 3*(BASE_SIZE-1)+3]; the
-// final byte sits inside the trailing slot.
-using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE + 1>;
-
-// Static assertion: storage must include at least one byte of pad
-// beyond the last valid slot so a 4-byte tail load is in-bounds.
-static_assert(sizeof(LowPlyHistory) >= sizeof(LowPlySlot) * HASHED_LOW_PLY_BASE_SIZE + 1,
-              "LowPlyHistory storage must extend at least 1 byte beyond the last "
-              "valid slot so a 4-byte load at index BASE_SIZE-1 stays in-bounds");
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
 
 struct LowPly {
-    static constexpr int     VALUE_LIMIT = 7183;
-    static constexpr int16_t INIT        = HASHED_LOW_PLY_INIT;
+    static constexpr int     VALUE_LIMIT   = 7183;
+    static constexpr int16_t VALUE_DEFAULT = HASHED_LOW_PLY_VALUE_DEFAULT;
 
     static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
                     && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
                   "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
-    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
-                    && INIT <= std::numeric_limits<std::int16_t>::max(),
-                  "LowPly::INIT must fit in int16_t");
+    static_assert(VALUE_DEFAULT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_DEFAULT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_DEFAULT must fit in int16_t");
 
     static inline sf_always_inline std::uint32_t input(int ply, std::uint16_t move_raw) {
         assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
@@ -201,27 +186,12 @@ struct LowPly {
     static inline sf_always_inline std::uint32_t idx_from(std::uint64_t h) {
         return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
     }
-    // 8-bit tag: take 8 bits of the hash above the index bits. Tag 0 is
-    // reserved as the empty sentinel; remap 0 -> 1 so any occupied slot
-    // tag is non-zero.
     static inline sf_always_inline std::uint8_t tag_from(std::uint64_t h) {
         const std::uint8_t t = std::uint8_t(h >> HASHED_LOW_PLY_INDEX_BITS);
         return t == 0 ? std::uint8_t(1) : t;
     }
-    // Pack a (value, tag) pair into the low 24 bits of a uint32_t. The
-    // high 8 bits are unused (next slot's first byte in storage).
-    static inline sf_always_inline constexpr std::uint32_t pack(int v, std::uint8_t tag) {
-        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
-    }
-    // Branchless extract: returns slot value when stored tag matches the
-    // queried tag, else INIT. Operates on the raw 32-bit word loaded
-    // from a slot address (low 24 bits = slot data, high 8 bits unused).
-    static inline sf_always_inline constexpr int extract(std::uint32_t raw, std::uint8_t tag) {
-        const std::uint32_t v       = std::uint32_t(std::uint16_t(raw & 0xFFFFu));
-        const std::uint8_t  slotTag = std::uint8_t((raw >> 16) & 0xFFu);
-        const std::uint32_t miss    = std::uint32_t(-std::int32_t(slotTag != tag));
-        const std::uint32_t initu   = std::uint32_t(std::uint16_t(INIT));
-        return int(std::int16_t((v & ~miss) | (initu & miss)));
+    static inline sf_always_inline constexpr int extract(const LowPlySlot& slot, std::uint8_t tag) {
+        return slot.tag == tag ? int(slot.value) : int(VALUE_DEFAULT);
     }
 };
 
@@ -229,14 +199,8 @@ struct LowPlyReadAccess {
     const LowPlySlot* slot;
     std::uint8_t      tag;
 
-    inline sf_always_inline int read() const {
-        // 4-byte load at slot address: low 16 bits = value, next 8 bits
-        // = stored tag, top 8 bits = next-slot byte (or tail pad).
-        std::uint32_t raw;
-        std::memcpy(&raw, slot, sizeof(raw));
-        return LowPly::extract(raw, tag);
-    }
-    inline sf_always_inline operator int() const { return read(); }
+    inline sf_always_inline int read() const { return LowPly::extract(*slot, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
 
     static inline sf_always_inline LowPlyReadAccess access(const LowPlyHistory& t,
                                                            int                  ply,
@@ -251,14 +215,10 @@ struct LowPlyAccess {
     std::uint8_t tag;
 
     inline sf_always_inline void operator<<(int bonus) {
-        std::uint32_t raw;
-        std::memcpy(&raw, slot, sizeof(raw));
         const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
-        int       v            = LowPly::extract(raw, tag);
+        int       v            = LowPly::extract(*slot, tag);
         v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
         assert(std::abs(v) <= LowPly::VALUE_LIMIT);
-        // Write only the 3 bytes of this slot; preserve the trailing
-        // byte (next slot's first byte) untouched.
         slot->value = std::int16_t(v);
         slot->tag   = tag;
     }
@@ -271,18 +231,16 @@ struct LowPlyAccess {
     }
 };
 
-// Compile-time round-trip checks of pack/extract.
-static_assert(LowPly::extract(LowPly::pack(0, 0), 0) == 0,
-              "extract(pack(0, 0), 0) must round-trip 0");
-static_assert(LowPly::extract(LowPly::pack(0, 0), 1) == LowPly::INIT,
-              "extract on tag mismatch must return INIT");
-static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+static_assert(LowPly::extract(LowPlySlot{0, 0}, 0) == 0,
+              "extract on matching tag must return slot value");
+static_assert(LowPly::extract(LowPlySlot{0, 0}, 1) == LowPly::VALUE_DEFAULT,
+              "extract on tag mismatch must return VALUE_DEFAULT");
+static_assert(LowPly::extract(LowPlySlot{LowPly::VALUE_LIMIT, 1}, 1) == LowPly::VALUE_LIMIT,
               "extract must round-trip positive VALUE_LIMIT");
-static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+static_assert(LowPly::extract(LowPlySlot{-LowPly::VALUE_LIMIT, 1}, 1) == -LowPly::VALUE_LIMIT,
               "extract must round-trip negative VALUE_LIMIT");
-static_assert(LowPly::extract(LowPly::pack(LowPly::INIT, HASHED_LOW_PLY_EMPTY_TAG), 1)
-                == LowPly::INIT,
-              "extract on cleared slot (empty tag) must return INIT for any non-empty query tag");
+static_assert(LowPly::extract(LowPlySlot{}, 1) == LowPly::VALUE_DEFAULT,
+              "default-constructed slot must return VALUE_DEFAULT for any non-empty query tag");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/history.h
+++ b/src/history.h
@@ -157,8 +157,22 @@ struct __attribute__((packed)) LowPlySlot {
         tag(t) {}
 };
 static_assert(sizeof(LowPlySlot) == 3, "LowPlySlot must be 3 bytes");
+static_assert(alignof(LowPlySlot) == 1, "LowPlySlot must be byte-aligned for 3-byte stride");
 
-using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE>;
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "LowPlySlot 32-bit read/write path assumes little-endian byte order");
+
+// One trailing slot of pad: the read/write fast path issues a 32-bit
+// load (and store) that overlaps the next slot's first byte; at the
+// last valid index that byte must be in-bounds storage.
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE + 1>;
+static_assert(sizeof(LowPlyHistory) >= sizeof(LowPlySlot) * HASHED_LOW_PLY_BASE_SIZE + 1,
+              "LowPlyHistory storage must extend at least 1 byte beyond the last "
+              "valid slot for the 32-bit tail load/store at index BASE_SIZE-1");
+
+// may_alias allows the compiler to type-pun a LowPlySlot through a
+// uint32_t pointer without violating strict aliasing.
+typedef std::uint32_t LowPlySlotRaw __attribute__((may_alias));
 
 struct LowPly {
     static constexpr int     VALUE_LIMIT   = 7183;
@@ -190,8 +204,13 @@ struct LowPly {
         const std::uint8_t t = std::uint8_t(h >> HASHED_LOW_PLY_INDEX_BITS);
         return t == 0 ? std::uint8_t(1) : t;
     }
-    static inline sf_always_inline constexpr int extract(const LowPlySlot& slot, std::uint8_t tag) {
-        return slot.tag == tag ? int(slot.value) : int(VALUE_DEFAULT);
+    static inline sf_always_inline constexpr std::uint32_t pack(int v, std::uint8_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    static inline sf_always_inline constexpr int extract(std::uint32_t raw, std::uint8_t tag) {
+        const std::int16_t v         = std::int16_t(std::uint16_t(raw));
+        const std::uint8_t storedTag = std::uint8_t(raw >> 16);
+        return storedTag == tag ? int(v) : int(VALUE_DEFAULT);
     }
 };
 
@@ -199,8 +218,11 @@ struct LowPlyReadAccess {
     const LowPlySlot* slot;
     std::uint8_t      tag;
 
-    inline sf_always_inline int read() const { return LowPly::extract(*slot, tag); }
-    inline sf_always_inline     operator int() const { return read(); }
+    inline sf_always_inline int read() const {
+        const std::uint32_t raw = *reinterpret_cast<const LowPlySlotRaw*>(slot);
+        return LowPly::extract(raw, tag);
+    }
+    inline sf_always_inline operator int() const { return read(); }
 
     static inline sf_always_inline LowPlyReadAccess access(const LowPlyHistory& t,
                                                            int                  ply,
@@ -215,12 +237,15 @@ struct LowPlyAccess {
     std::uint8_t tag;
 
     inline sf_always_inline void operator<<(int bonus) {
-        const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
-        int       v            = LowPly::extract(*slot, tag);
+        auto* const   rawPtr       = reinterpret_cast<LowPlySlotRaw*>(slot);
+        std::uint32_t raw          = *rawPtr;
+        int           v            = LowPly::extract(raw, tag);
+        const int     clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
         v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
         assert(std::abs(v) <= LowPly::VALUE_LIMIT);
-        slot->value = std::int16_t(v);
-        slot->tag   = tag;
+        // Preserve the high 8 bits (next slot's first byte, or trailing
+        // pad) and update the low 24 bits with the new (value, tag).
+        *rawPtr = (raw & 0xFF000000u) | LowPly::pack(v, tag);
     }
 
     static inline sf_always_inline LowPlyAccess access(LowPlyHistory& t,
@@ -231,16 +256,14 @@ struct LowPlyAccess {
     }
 };
 
-static_assert(LowPly::extract(LowPlySlot{0, 0}, 0) == 0,
-              "extract on matching tag must return slot value");
-static_assert(LowPly::extract(LowPlySlot{0, 0}, 1) == LowPly::VALUE_DEFAULT,
+static_assert(LowPly::extract(LowPly::pack(0, 0), 0) == 0,
+              "extract(pack(0, 0), 0) must round-trip 0");
+static_assert(LowPly::extract(LowPly::pack(0, 0), 1) == LowPly::VALUE_DEFAULT,
               "extract on tag mismatch must return VALUE_DEFAULT");
-static_assert(LowPly::extract(LowPlySlot{LowPly::VALUE_LIMIT, 1}, 1) == LowPly::VALUE_LIMIT,
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
               "extract must round-trip positive VALUE_LIMIT");
-static_assert(LowPly::extract(LowPlySlot{-LowPly::VALUE_LIMIT, 1}, 1) == -LowPly::VALUE_LIMIT,
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
               "extract must round-trip negative VALUE_LIMIT");
-static_assert(LowPly::extract(LowPlySlot{}, 1) == LowPly::VALUE_DEFAULT,
-              "default-constructed slot must return VALUE_DEFAULT for any non-empty query tag");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/history.h
+++ b/src/history.h
@@ -145,16 +145,24 @@ using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZ
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root
-struct __attribute__((packed)) LowPlySlot {
-    std::int16_t value;
-    std::uint8_t tag;
+//
+// Slot is a 3-byte byte array. Layout (little-endian uint32_t view):
+//   bytes[0] = low  byte of int16_t value
+//   bytes[1] = high byte of int16_t value
+//   bytes[2] = uint8_t tag
+// Using a byte array (rather than a struct of `int16_t value; uint8_t tag;`
+// with `__attribute__((packed))`) keeps `sizeof == 3, alignof == 1` without
+// any compiler-specific packing attribute.
+struct LowPlySlot {
+    std::uint8_t bytes[3];
 
     constexpr LowPlySlot() noexcept :
-        value(HASHED_LOW_PLY_VALUE_DEFAULT),
-        tag(HASHED_LOW_PLY_EMPTY_TAG) {}
+        bytes{std::uint8_t(std::uint16_t(HASHED_LOW_PLY_VALUE_DEFAULT) & 0xFFu),
+              std::uint8_t((std::uint16_t(HASHED_LOW_PLY_VALUE_DEFAULT) >> 8) & 0xFFu),
+              HASHED_LOW_PLY_EMPTY_TAG} {}
     constexpr LowPlySlot(std::int16_t v, std::uint8_t t) noexcept :
-        value(v),
-        tag(t) {}
+        bytes{std::uint8_t(std::uint16_t(v) & 0xFFu), std::uint8_t((std::uint16_t(v) >> 8) & 0xFFu),
+              t} {}
 };
 static_assert(sizeof(LowPlySlot) == 3, "LowPlySlot must be 3 bytes");
 static_assert(alignof(LowPlySlot) == 1, "LowPlySlot must be byte-aligned for 3-byte stride");

--- a/src/history.h
+++ b/src/history.h
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <type_traits>  // IWYU pragma: keep
 
@@ -41,11 +42,20 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_LOW_PLY_INDEX_BITS = 16;
+constexpr size_t   HASHED_LOW_PLY_BASE_SIZE  = size_t(1) << HASHED_LOW_PLY_INDEX_BITS;
+constexpr uint32_t HASHED_LOW_PLY_INDEX_MASK = uint32_t(HASHED_LOW_PLY_BASE_SIZE - 1);
+constexpr int16_t  HASHED_LOW_PLY_INIT       = 98;
+constexpr uint8_t  HASHED_LOW_PLY_EMPTY_TAG  = 0;
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_LOW_PLY_BASE_SIZE & (HASHED_LOW_PLY_BASE_SIZE - 1)) == 0,
+              "HASHED_LOW_PLY_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -134,9 +144,145 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: tagged hashed table keyed by (ply, move.raw()).
+// Slot is 3 bytes: int16_t value followed by uint8_t tag. The fast read
+// path issues a 4-byte load and unpacks; the trailing byte is the next
+// slot's first byte, or tail padding for the last valid slot.
+struct __attribute__((packed)) LowPlySlot {
+    std::int16_t value;
+    std::uint8_t tag;
+
+    constexpr LowPlySlot() noexcept :
+        value(HASHED_LOW_PLY_INIT),
+        tag(HASHED_LOW_PLY_EMPTY_TAG) {}
+    constexpr LowPlySlot(std::int16_t v, std::uint8_t t) noexcept :
+        value(v),
+        tag(t) {}
+};
+static_assert(sizeof(LowPlySlot) == 3, "LowPlySlot must be 3 bytes");
+static_assert(alignof(LowPlySlot) == 1, "LowPlySlot must be byte-aligned for 3-byte stride");
+
+// One trailing slot beyond HASHED_LOW_PLY_BASE_SIZE provides padding so
+// that a 4-byte load at the last valid index does not overflow the
+// storage. With sizeof(LowPlySlot)==3, the 4-byte load at index
+// BASE_SIZE-1 reads bytes [3*(BASE_SIZE-1), 3*(BASE_SIZE-1)+3]; the
+// final byte sits inside the trailing slot.
+using LowPlyHistory = std::array<LowPlySlot, HASHED_LOW_PLY_BASE_SIZE + 1>;
+
+// Static assertion: storage must include at least one byte of pad
+// beyond the last valid slot so a 4-byte tail load is in-bounds.
+static_assert(sizeof(LowPlyHistory) >= sizeof(LowPlySlot) * HASHED_LOW_PLY_BASE_SIZE + 1,
+              "LowPlyHistory storage must extend at least 1 byte beyond the last "
+              "valid slot so a 4-byte load at index BASE_SIZE-1 stays in-bounds");
+
+struct LowPly {
+    static constexpr int     VALUE_LIMIT = 7183;
+    static constexpr int16_t INIT        = HASHED_LOW_PLY_INIT;
+
+    static_assert(-VALUE_LIMIT >= std::numeric_limits<std::int16_t>::min()
+                    && VALUE_LIMIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::VALUE_LIMIT must fit in int16_t for packed-slot storage");
+    static_assert(INIT >= std::numeric_limits<std::int16_t>::min()
+                    && INIT <= std::numeric_limits<std::int16_t>::max(),
+                  "LowPly::INIT must fit in int16_t");
+
+    static inline sf_always_inline std::uint32_t input(int ply, std::uint16_t move_raw) {
+        assert(0 <= ply && ply < LOW_PLY_HISTORY_SIZE);
+        return (std::uint32_t(unsigned(ply)) << 16) | move_raw;
+    }
+    static inline sf_always_inline std::uint64_t mix(std::uint32_t in) {
+        std::uint64_t k = in;
+        k *= 0x9E3779B97F4A7C15ULL;
+        k ^= k >> 32;
+        k *= 0xBF58476D1CE4E5B9ULL;
+        k ^= k >> 27;
+        return k;
+    }
+    static inline sf_always_inline std::uint32_t idx_from(std::uint64_t h) {
+        return std::uint32_t(h) & HASHED_LOW_PLY_INDEX_MASK;
+    }
+    // 8-bit tag: take 8 bits of the hash above the index bits. Tag 0 is
+    // reserved as the empty sentinel; remap 0 -> 1 so any occupied slot
+    // tag is non-zero.
+    static inline sf_always_inline std::uint8_t tag_from(std::uint64_t h) {
+        const std::uint8_t t = std::uint8_t(h >> HASHED_LOW_PLY_INDEX_BITS);
+        return t == 0 ? std::uint8_t(1) : t;
+    }
+    // Pack a (value, tag) pair into the low 24 bits of a uint32_t. The
+    // high 8 bits are unused (next slot's first byte in storage).
+    static inline sf_always_inline constexpr std::uint32_t pack(int v, std::uint8_t tag) {
+        return std::uint32_t(std::uint16_t(v)) | (std::uint32_t(tag) << 16);
+    }
+    // Branchless extract: returns slot value when stored tag matches the
+    // queried tag, else INIT. Operates on the raw 32-bit word loaded
+    // from a slot address (low 24 bits = slot data, high 8 bits unused).
+    static inline sf_always_inline constexpr int extract(std::uint32_t raw, std::uint8_t tag) {
+        const std::uint32_t v       = std::uint32_t(std::uint16_t(raw & 0xFFFFu));
+        const std::uint8_t  slotTag = std::uint8_t((raw >> 16) & 0xFFu);
+        const std::uint32_t miss    = std::uint32_t(-std::int32_t(slotTag != tag));
+        const std::uint32_t initu   = std::uint32_t(std::uint16_t(INIT));
+        return int(std::int16_t((v & ~miss) | (initu & miss)));
+    }
+};
+
+struct LowPlyReadAccess {
+    const LowPlySlot* slot;
+    std::uint8_t      tag;
+
+    inline sf_always_inline int read() const {
+        // 4-byte load at slot address: low 16 bits = value, next 8 bits
+        // = stored tag, top 8 bits = next-slot byte (or tail pad).
+        std::uint32_t raw;
+        std::memcpy(&raw, slot, sizeof(raw));
+        return LowPly::extract(raw, tag);
+    }
+    inline sf_always_inline operator int() const { return read(); }
+
+    static inline sf_always_inline LowPlyReadAccess access(const LowPlyHistory& t,
+                                                           int                  ply,
+                                                           std::uint16_t        move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+struct LowPlyAccess {
+    LowPlySlot*  slot;
+    std::uint8_t tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        std::uint32_t raw;
+        std::memcpy(&raw, slot, sizeof(raw));
+        const int clampedBonus = std::clamp(bonus, -LowPly::VALUE_LIMIT, LowPly::VALUE_LIMIT);
+        int       v            = LowPly::extract(raw, tag);
+        v += clampedBonus - v * std::abs(clampedBonus) / LowPly::VALUE_LIMIT;
+        assert(std::abs(v) <= LowPly::VALUE_LIMIT);
+        // Write only the 3 bytes of this slot; preserve the trailing
+        // byte (next slot's first byte) untouched.
+        slot->value = std::int16_t(v);
+        slot->tag   = tag;
+    }
+
+    static inline sf_always_inline LowPlyAccess access(LowPlyHistory& t,
+                                                       int            ply,
+                                                       std::uint16_t  move_raw) {
+        const std::uint64_t h = LowPly::mix(LowPly::input(ply, move_raw));
+        return {&t[LowPly::idx_from(h)], LowPly::tag_from(h)};
+    }
+};
+
+// Compile-time round-trip checks of pack/extract.
+static_assert(LowPly::extract(LowPly::pack(0, 0), 0) == 0,
+              "extract(pack(0, 0), 0) must round-trip 0");
+static_assert(LowPly::extract(LowPly::pack(0, 0), 1) == LowPly::INIT,
+              "extract on tag mismatch must return INIT");
+static_assert(LowPly::extract(LowPly::pack(LowPly::VALUE_LIMIT, 1), 1) == LowPly::VALUE_LIMIT,
+              "extract must round-trip positive VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(-LowPly::VALUE_LIMIT, 1), 1) == -LowPly::VALUE_LIMIT,
+              "extract must round-trip negative VALUE_LIMIT");
+static_assert(LowPly::extract(LowPly::pack(LowPly::INIT, HASHED_LOW_PLY_EMPTY_TAG), 1)
+                == LowPly::INIT,
+              "extract on cleared slot (empty tag) must return INIT for any non-empty query tag");
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * LowPlyReadAccess::access(*lowPlyHistory, ply, m.raw()) / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -317,6 +317,14 @@ bool Search::Worker::iterative_deepening() {
 
     lowPlyHistory.fill(LowPlySlot{});
 
+    // Dynamic check: 32-bit load at the last valid slot index. The +1
+    // trailing pad in LowPlyHistory keeps this load in-bounds.
+    {
+        const std::uint32_t lastSlotProbe =
+          *reinterpret_cast<const LowPlySlotRaw*>(&lowPlyHistory[HASHED_LOW_PLY_BASE_SIZE - 1]);
+        assert(LowPly::extract(lastSlotProbe, HASHED_LOW_PLY_EMPTY_TAG) == LowPly::VALUE_DEFAULT);
+    }
+
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,7 +315,7 @@ bool Search::Worker::iterative_deepening() {
     int  searchAgainCounter = 0;
     bool uciPvSent          = false;
 
-    lowPlyHistory.fill(98);
+    lowPlyHistory.fill(LowPlySlot{});
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        LowPlyAccess::access(workerThread.lowPlyHistory, ss->ply, move.raw()) << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Hashed lowply (`lowply-hashed-pf` family) with the slot shrunk from 4 bytes to 3 bytes (1-byte tag + 2-byte value) and no prefetch. Fast path issues a single 32-bit load (and a 32-bit RMW store on writes) via a `may_alias` typedef. Storage is exactly `BASE_SIZE * 3 + 1` bytes per worker (192 KiB).

Bench: 3175410