### PR TITLE
Hashed contcorr i17 with branchless strict magnitude gate

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -41,11 +41,18 @@ constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
+constexpr int      HASHED_CONTCORR_INDEX_BITS = 17;
+constexpr size_t   HASHED_CONTCORR_BASE_SIZE  = size_t(1) << HASHED_CONTCORR_INDEX_BITS;
+constexpr uint32_t HASHED_CONTCORR_INDEX_MASK = uint32_t(HASHED_CONTCORR_BASE_SIZE - 1);
+
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((HASHED_CONTCORR_BASE_SIZE & (HASHED_CONTCORR_BASE_SIZE - 1)) == 0,
+              "HASHED_CONTCORR_BASE_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -214,6 +221,104 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+struct alignas(2) HashedContCorrSlot {
+    using Tag = std::uint8_t;
+
+    static constexpr int     TAG_BITS = 5;
+    static constexpr Tag     TAG_MASK = Tag((1u << TAG_BITS) - 1);
+    static constexpr int16_t INIT     = 6;
+    static constexpr int16_t NOK      = 8;
+
+    static constexpr int WORD_BITS  = 16;
+    static constexpr int VALUE_BITS = WORD_BITS - TAG_BITS;
+    static constexpr int VALUE_MAX  = (1 << (VALUE_BITS - 1)) - 1;
+    static constexpr int VALUE_MIN  = -(1 << (VALUE_BITS - 1));
+
+    static constexpr std::size_t GRAVITY_SHIFT_BITS = ilog2(std::size_t(CORRECTION_HISTORY_LIMIT));
+
+    static_assert(VALUE_BITS == 11, "HashedContCorrSlot value field must be 11 bits");
+    static_assert(CORRECTION_HISTORY_LIMIT <= 1024,
+                  "value is an 11-bit saturated signed field; widen the field or "
+                  "lower CORRECTION_HISTORY_LIMIT if this grows");
+    static_assert((std::size_t(1) << GRAVITY_SHIFT_BITS) == std::size_t(CORRECTION_HISTORY_LIMIT),
+                  "CORRECTION_HISTORY_LIMIT must be a power of 2 for shift-based gravity");
+
+    std::uint16_t word;
+
+    static inline sf_always_inline constexpr std::uint16_t pack(int v, Tag t) {
+        return std::uint16_t((std::uint32_t(v) << TAG_BITS) | std::uint32_t(t));
+    }
+    static inline sf_always_inline constexpr std::uint16_t empty_data() {
+        return pack(INIT, Tag(0));
+    }
+
+    static inline sf_always_inline constexpr int extract(std::uint16_t w, Tag t) {
+        const std::uint32_t u         = std::uint32_t(std::uint16_t(w));
+        const std::uint32_t storedTag = u & std::uint32_t(TAG_MASK);
+        const int           v         = int(std::int16_t(w)) >> TAG_BITS;
+        const std::uint32_t mask      = std::uint32_t(-std::int32_t(storedTag != std::uint32_t(t)));
+        return int(int32_t((std::uint32_t(v) & ~mask) | (std::uint32_t(INIT) & mask)));
+    }
+
+    static inline sf_always_inline int read(std::uint16_t w, Tag t) { return extract(w, t); }
+
+    static inline sf_always_inline void update(HashedContCorrSlot& s, Tag t, int b) {
+        assert((t & ~TAG_MASK) == 0);
+        assert(std::abs(b) <= CORRECTION_HISTORY_LIMIT);
+        const std::uint16_t oldWord      = s.word;
+        const int           u            = int(std::int16_t(oldWord));
+        const int           storedTag    = u & int(TAG_MASK);
+        const int           v_old        = u >> TAG_BITS;
+        const Tag           effectiveTag = (b != 0) ? t : Tag(storedTag);
+        const bool          tagMatch     = (storedTag == int(effectiveTag));
+        int                 v            = tagMatch ? v_old : int(INIT);
+        v                                = v + b - ((v * std::abs(b)) >> GRAVITY_SHIFT_BITS);
+        v                                = std::min(v, int(VALUE_MAX));
+        assert(VALUE_MIN <= v && v <= VALUE_MAX);
+        const std::uint16_t newWord   = pack(v, effectiveTag);
+        const bool          gateAllow = tagMatch || std::abs(v) > std::abs(v_old);
+        s.word                        = gateAllow ? newWord : oldWord;
+    }
+};
+static_assert(sizeof(HashedContCorrSlot) == 2, "HashedContCorrSlot must be 2 bytes");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::empty_data(),
+                                          HashedContCorrSlot::Tag(0))
+                == HashedContCorrSlot::INIT,
+              "empty_data must return INIT for tag 0");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::empty_data(),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::INIT,
+              "empty_data must return INIT for non-zero tag");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::pack(HashedContCorrSlot::VALUE_MAX,
+                                                                   HashedContCorrSlot::Tag(1)),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::VALUE_MAX,
+              "pack/extract round-trip positive VALUE_MAX");
+static_assert(HashedContCorrSlot::extract(HashedContCorrSlot::pack(HashedContCorrSlot::VALUE_MIN,
+                                                                   HashedContCorrSlot::Tag(1)),
+                                          HashedContCorrSlot::Tag(1))
+                == HashedContCorrSlot::VALUE_MIN,
+              "pack/extract round-trip negative VALUE_MIN");
+
+struct HashedContCorrReadAccess {
+    const HashedContCorrSlot* slot;
+    HashedContCorrSlot::Tag   tag;
+
+    inline sf_always_inline int read() const { return HashedContCorrSlot::read(slot->word, tag); }
+    inline sf_always_inline     operator int() const { return read(); }
+};
+
+struct HashedContCorrAccess {
+    HashedContCorrSlot*     slot;
+    HashedContCorrSlot::Tag tag;
+
+    inline sf_always_inline void operator<<(int bonus) {
+        HashedContCorrSlot::update(*slot, tag, bonus);
+    }
+};
+
+using HashedContCorrHistory = std::array<HashedContCorrSlot, HASHED_CONTCORR_BASE_SIZE>;
 
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,15 @@
 
 namespace Stockfish {
 
+constexpr std::size_t ilog2(const std::size_t x) {
+    assert(x >= 1);
+    std::size_t y = x;
+    std::size_t n = 0;
+    while (y >>= 1)
+        ++n;
+    return n;
+}
+
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,18 +81,66 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Encode a (piece, square) pair into a 10-bit contcorrIndex for the
+// hashed continuation-correction hash. NO_PIECE paired with SQ_A1 is the canonical
+// zero sentinel used before the root.
+static_assert(unsigned(NO_PIECE) == 0 && unsigned(SQ_A1) == 0,
+              "contcorr zero sentinel assumes NO_PIECE on SQ_A1 encodes to 0");
+static_assert(unsigned(PIECE_NB) * unsigned(SQUARE_NB) <= (1u << 10),
+              "contcorr_index must fit in 10 bits");
+unsigned contcorr_index(Piece pc, Square sq) {
+    return unsigned(pc) * unsigned(SQUARE_NB) + unsigned(sq);
+}
+
+// 64-bit mixer producing both a table index and a verification tag from
+// two 10-bit contcorrIndex inputs.
+uint64_t contcorr_mix(uint32_t a, uint32_t b) {
+    uint64_t k = (uint64_t(a) << 10) | b;
+    k *= 0x9E3779B97F4A7C15ULL;
+    k ^= k >> 32;
+    k *= 0xBF58476D1CE4E5B9ULL;
+    k ^= k >> 27;
+    return k;
+}
+
+uint32_t contcorr_idx_from(uint64_t h) { return uint32_t(h) & HASHED_CONTCORR_INDEX_MASK; }
+
+HashedContCorrSlot::Tag contcorr_tag_from(uint64_t h) {
+    const HashedContCorrSlot::Tag t = HashedContCorrSlot::Tag(
+      uint32_t(h >> HASHED_CONTCORR_INDEX_BITS) & HashedContCorrSlot::TAG_MASK);
+    return t == 0 ? HashedContCorrSlot::Tag(1) : t;
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
-    const Color us     = pos.side_to_move();
-    const auto  m      = (ss - 1)->currentMove;
+    const Color us = pos.side_to_move();
+
+    const Move   m  = (ss - 1)->currentMove;
+    const Square to = m.to_sq_unchecked();
+    const Piece  pc = pos.piece_on(to);
+
+    const auto contcorrIndex = contcorr_index(pc, to);
+    const auto hashA         = contcorr_mix(contcorrIndex, (ss - 2)->contcorrIndex);
+    const auto hashB         = contcorr_mix(contcorrIndex, (ss - 4)->contcorrIndex);
+    const auto idxA          = contcorr_idx_from(hashA);
+    const auto idxB          = contcorr_idx_from(hashB);
+    const auto tagA          = contcorr_tag_from(hashA);
+    const auto tagB          = contcorr_tag_from(hashB);
+
+    const auto& table = w.hashedContCorrHistory;
+    prefetch(&table[idxA]);
+    prefetch(&table[idxB]);
+
     const auto& shared = w.sharedHistory;
     const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
     const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
-    const int   cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                    + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                  : 8;
+
+    const HashedContCorrReadAccess accA{&table[idxA], tagA};
+    const HashedContCorrReadAccess accB{&table[idxB], tagB};
+    const int                      rawSum = accA.read() + accB.read();
+
+    const int cntcv = HashedContCorrSlot::NOK + (rawSum - HashedContCorrSlot::NOK) * int(m.is_ok());
 
     return 12153 * pcv + 8620 * micv + 12355 * (wnpcv + bnpcv) + 7982 * cntcv;
 }
@@ -107,8 +155,23 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
-    const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
+
+    const Move   m  = (ss - 1)->currentMove;
+    const Square to = m.to_sq_unchecked();
+    const Piece  pc = pos.piece_on(to);
+
+    const auto contcorrIndex = contcorr_index(pc, to);
+    const auto hashA         = contcorr_mix(contcorrIndex, (ss - 2)->contcorrIndex);
+    const auto hashB         = contcorr_mix(contcorrIndex, (ss - 4)->contcorrIndex);
+    const auto idxA          = contcorr_idx_from(hashA);
+    const auto idxB          = contcorr_idx_from(hashB);
+    const auto tagA          = contcorr_tag_from(hashA);
+    const auto tagB          = contcorr_tag_from(hashB);
+
+    auto& table = workerThread.hashedContCorrHistory;
+    prefetch(&table[idxA]);
+    prefetch(&table[idxB]);
 
     constexpr int nonPawnWeight = 187;
     auto&         shared        = workerThread.sharedHistory;
@@ -118,13 +181,11 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
-    {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(to);
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
-    }
+    const int            gatedBonus = int(m.is_ok()) * bonus;
+    HashedContCorrAccess accA{&table[idxA], tagA};
+    HashedContCorrAccess accB{&table[idxB], tagB};
+    accA << gatedBonus * 126 / 128;
+    accB << gatedBonus * 63 / 128;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -285,12 +346,13 @@ bool Search::Worker::iterative_deepening() {
     {
         (ss - i)->continuationHistory =
           &continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
-        (ss - i)->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
-        (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->contcorrIndex = 0;
+        (ss - i)->staticEval    = VALUE_NONE;
     }
+    ss->contcorrIndex = 0;
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
-        (ss + i)->ply = i;
+        (ss + i)->ply = uint16_t(i);
 
     ss->pv = &pv;
 
@@ -596,16 +658,15 @@ void Search::Worker::do_move(
         ss->currentMove = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
-        ss->continuationCorrectionHistory =
-          &continuationCorrectionHistory[dirtyPiece.pc][move.to_sq()];
+        ss->contcorrIndex = uint16_t(contcorr_index(dirtyPiece.pc, move.to_sq()));
     }
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
-    ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
-    ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
+    ss->currentMove         = Move::null();
+    ss->continuationHistory = &continuationHistory[0][0][NO_PIECE][0];
+    ss->contcorrIndex       = 0;
 }
 
 void Search::Worker::undo_move(Position& pos, const Move move) {
@@ -627,9 +688,7 @@ void Search::Worker::clear() {
 
     ttMoveHistory = 0;
 
-    for (auto& to : continuationCorrectionHistory)
-        for (auto& h : to)
-            h.fill(6);
+    hashedContCorrHistory.fill(HashedContCorrSlot{HashedContCorrSlot::empty_data()});
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/search.h
+++ b/src/search.h
@@ -103,21 +103,21 @@ struct PVMoves {
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
 struct Stack {
-    PVMoves*                    pv;
-    PieceToHistory*             continuationHistory;
-    CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    PVMoves*        pv;
+    PieceToHistory* continuationHistory;
+    int             statScore;
+    Move            currentMove;
+    Move            excludedMove;
+    Value           staticEval;
+    uint16_t        moveCount;
+    uint16_t        contcorrIndex;
+    int16_t         cutoffCnt;
+    int16_t         reduction;
+    uint16_t        ply;
+    bool            inCheck;
+    bool            ttPv;
+    bool            ttHit;
+    bool            followPV;
 };
 
 
@@ -331,9 +331,9 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
+    HashedContCorrHistory hashedContCorrHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Branchless sibling of contcorr-hashed-i17-shift-pf-strict-gate. Replaces the early-return on gate-fire with a select: always compute newWord, then write gateAllow ? newWord : oldWord. Removes the conditional jump and lets the compiler emit a cmov-style selection that does not depend on PGO branch-prediction heuristics.

On this PGO build (avx512icl), branched and branchless variants produce identical bench and identical search<NonPV> instruction counts; PGO already selects branchless codegen for the branched form. The branchless source is preserved as the canonical form for non-PGO builds, alternative compilers, and ARM.

Bench: 2995352