### PR TITLE
Bulk prefetch lowPlyHistory for QUIETS

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -139,6 +139,14 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         threatByLesser[KING]  = 0;
     }
 
+    if constexpr (Type == QUIETS)
+        if (ply < LOW_PLY_HISTORY_SIZE)
+        {
+            const auto& lph = (*lowPlyHistory)[ply];
+            for (const auto& mv : ml)
+                prefetch(&lph[mv.raw()]);
+        }
+
     ExtMove* it = cur;
     for (auto move : ml)
     {


### PR DESCRIPTION
Bulk-prefetches lowPlyHistory[ply][move.raw()] for every move in the list before the QUIETS scoring loop in MovePicker::score. Mirrors the prefetch placement of lowply-hashed-pf but applied to master's normal lowPlyHistory (no hashing). Bench: 2723949