### PR TITLE
Look-ahead-2 rolling prefetch for lowPlyHistory

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -139,6 +139,27 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         threatByLesser[KING]  = 0;
     }
 
+    const Move* mv_end   = nullptr;
+    const Move* mv_ahead = nullptr;
+
+    if constexpr (Type == QUIETS)
+        if (ply < LOW_PLY_HISTORY_SIZE)
+        {
+            mv_end          = ml.end();
+            mv_ahead        = ml.begin();
+            const auto& lph = (*lowPlyHistory)[ply];
+            if (mv_ahead != mv_end)
+            {
+                prefetch(&lph[mv_ahead->raw()]);
+                ++mv_ahead;
+                if (mv_ahead != mv_end)
+                {
+                    prefetch(&lph[mv_ahead->raw()]);
+                    ++mv_ahead;
+                }
+            }
+        }
+
     ExtMove* it = cur;
     for (auto move : ml)
     {
@@ -176,7 +197,15 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+            {
+                const auto& lph = (*lowPlyHistory)[ply];
+                m.value += 8 * lph[m.raw()] / (1 + ply);
+                if (mv_ahead != mv_end)
+                {
+                    prefetch(&lph[mv_ahead->raw()]);
+                    ++mv_ahead;
+                }
+            }
         }
 
         else  // Type == EVASIONS


### PR DESCRIPTION
Look-ahead-2 rolling prefetch for lowPlyHistory in the QUIETS scoring loop of MovePicker::score. Prefetches the first two moves before the loop, then keeps a 2-ahead pointer that advances after each scored move. Mirrors the placement of lowply-hashed-pf-la2-rc applied to master's normal lowPlyHistory (no hashing). Bench: 2723949