### PR TITLE
Templated update_continuation_histories without inline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1893,7 +1893,8 @@ void update_all_stats(const Position& pos,
 // Updates the continuation histories for the move pairs formed by
 // the current move and the moves played in previous plies.
 template<bool InCheck>
-static void update_continuation_histories_impl(Stack* ss, Piece pc, Square to, int bonus) {
+static sf_noinline void
+update_continuation_histories_impl(Stack* ss, Piece pc, Square to, int bonus) {
 
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1071}, {2, 753}, {3, 329}, {4, 539}, {5, 124}, {6, 434}}};

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1892,19 +1892,22 @@ void update_all_stats(const Position& pos,
 
 // Updates the continuation histories for the move pairs formed by
 // the current move and the moves played in previous plies.
-void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
+template<bool InCheck>
+static void update_continuation_histories_impl(Stack* ss, Piece pc, Square to, int bonus) {
+
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1071}, {2, 753}, {3, 329}, {4, 539}, {5, 124}, {6, 434}}};
+
+    // Only update the first 2 continuation histories if we are in check
+    constexpr std::size_t N = InCheck ? 2 : conthist_bonuses.size();
 
     // Multipliers for positive history consistency
     constexpr int CMHCMultipliers[] = {96, 100, 100, 100, 115, 118, 129};
     int           positiveCount     = 0;
 
-    for (const auto [i, weight] : conthist_bonuses)
+    for (std::size_t k = 0; k < N; ++k)
     {
-        // Only update the first 2 continuation histories if we are in check
-        if (ss->inCheck && i > 2)
-            break;
+        const auto [i, weight] = conthist_bonuses[k];
 
         if (((ss - i)->currentMove).is_ok())
         {
@@ -1916,6 +1919,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             historyEntry << (bonus * weight * multiplier / 131072) + 73 * (i < 2);
         }
     }
+}
+
+void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
+    if (ss->inCheck)
+        update_continuation_histories_impl<true>(ss, pc, to, bonus);
+    else
+        update_continuation_histories_impl<false>(ss, pc, to, bonus);
 }
 
 // Updates move sorting heuristics


### PR DESCRIPTION
Sibling of update-conthist-templated that omits the inline keyword on update_continuation_histories_impl. The templated implementation is static (internal linkage) but not inline; the optimizer is free to inline based on size and call-site heuristics rather than the explicit hint. Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal search algorithm performance through compile-time improvements to continuation-history tracking

* **Chores**
  * Added compiler attribute support infrastructure for function optimization directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->