### PR TITLE
Templated MovePicker::score on LowPly bool with sf_noinline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -121,8 +121,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
 // Assigns a numerical value to each move in a list, used for sorting.
 // Captures are ordered by Most Valuable Victim (MVV), preferring captures
 // with a good history. Quiets moves are ordered using the history tables.
-template<GenType Type>
-ExtMove* MovePicker::score(const MoveList<Type>& ml) {
+template<GenType Type, bool LowPly>
+sf_noinline ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
     static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
@@ -175,7 +175,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             m.value += PieceValue[pt] * v;
 
 
-            if (ply < LOW_PLY_HISTORY_SIZE)
+            if constexpr (LowPly)
                 m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
         }
 
@@ -225,7 +225,7 @@ top:
         MoveList<CAPTURES> ml(pos);
 
         cur = endBadCaptures = moves;
-        endCur = endCaptures = score<CAPTURES>(ml);
+        endCur = endCaptures = score<CAPTURES, false>(ml);
 
         partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
         ++stage;
@@ -249,7 +249,8 @@ top:
         {
             MoveList<QUIETS> ml(pos);
 
-            endCur = endGenerated = score<QUIETS>(ml);
+            endCur = endGenerated =
+              ply < LOW_PLY_HISTORY_SIZE ? score<QUIETS, true>(ml) : score<QUIETS, false>(ml);
 
             partial_insertion_sort(cur, endCur, -3560 * depth);
         }
@@ -289,7 +290,7 @@ top:
         MoveList<EVASIONS> ml(pos);
 
         cur    = moves;
-        endCur = endGenerated = score<EVASIONS>(ml);
+        endCur = endGenerated = score<EVASIONS, false>(ml);
 
         partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
         ++stage;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -54,7 +54,7 @@ class MovePicker {
    private:
     template<typename Pred>
     Move select(Pred);
-    template<GenType T>
+    template<GenType T, bool LowPly>
     ExtMove* score(const MoveList<T>&);
     ExtMove* begin() { return cur; }
     ExtMove* end() { return endCur; }


### PR DESCRIPTION
Sibling of score-lowply-templated that adds sf_noinline (new macro in misc.h) and applies it to MovePicker::score.

Disassembly (GCC 15.2 mingw avxvnni PGO):

| Variant | MovePicker::next_move() body |
|---------|------------------------------|
| master | 1779 disassembly lines |
| score-lowply-templated | 1986 (+12%) |
| score-lowply-templated-noinline | 1698 (-4.5% vs master) |

Without sf_noinline, GCC LTO inlines all four score instantiations (CAPTURES/false, QUIETS/true, QUIETS/false, EVASIONS/false) into the single out-of-line next_move(). next_move grows because both QUIETS bodies sit side-by-side in one hot move-loop function. sf_noinline keeps each specialization as its own out-of-line symbol; next_move shrinks below master because score is no longer inlined at all.

Bench: 2723949