### PR TITLE
Split insertion sort and apply sf_noinline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -56,6 +56,7 @@ enum Stages {
 };
 
 
+// Sort moves in descending order.
 sf_noinline void insertion_sort(ExtMove* begin, ExtMove* end) {
 
     for (ExtMove* p = begin + 1; p < end; ++p)
@@ -67,6 +68,8 @@ sf_noinline void insertion_sort(ExtMove* begin, ExtMove* end) {
     }
 }
 
+// Sort moves in descending order up to and including a given limit.
+// The order of moves smaller than the limit is left unspecified.
 sf_noinline void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,7 +19,6 @@
 #include "movepick.h"
 
 #include <cassert>
-#include <limits>
 #include <utility>
 
 #include "bitboard.h"
@@ -57,9 +56,18 @@ enum Stages {
 };
 
 
-// Sort moves in descending order up to and including a given limit.
-// The order of moves smaller than the limit is left unspecified.
-void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
+sf_noinline void insertion_sort(ExtMove* begin, ExtMove* end) {
+
+    for (ExtMove* p = begin + 1; p < end; ++p)
+    {
+        ExtMove tmp = *p, *q;
+        for (q = p; q != begin && *(q - 1) < tmp; --q)
+            *q = *(q - 1);
+        *q = tmp;
+    }
+}
+
+sf_noinline void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
         if (p->value >= limit)
@@ -227,7 +235,7 @@ top:
         cur = endBadCaptures = moves;
         endCur = endCaptures = score<CAPTURES>(ml);
 
-        partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
+        insertion_sort(cur, endCur);
         ++stage;
         goto top;
     }
@@ -291,7 +299,7 @@ top:
         cur    = moves;
         endCur = endGenerated = score<EVASIONS>(ml);
 
-        partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
+        insertion_sort(cur, endCur);
         ++stage;
         [[fallthrough]];
     }


### PR DESCRIPTION
Sibling of insertion-sort-split with sf_noinline applied to both helpers (insertion_sort and partial_insertion_sort).

MovePicker::next_move() body size (GCC 15.2 mingw avxvnni PGO):

| Variant | next_move | Out-of-line helpers |
|---------|-----------|---------------------|
| master | 1779 lines | none |
| insertion-sort-split | 1794 lines | none |
| insertion-sort-split-noinline | 1710 lines | insertion_sort (28), partial_insertion_sort (50) |

next_move shrinks below master because both sort bodies are now called rather than inlined three times. Total code in memory is also smaller than master.

Bench: 2723949