### PR TITLE
Force update_continuation_histories out of line via sf_noinline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -128,12 +128,12 @@ void update_correction_history(const Position& pos,
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
-Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
-Value value_to_tt(Value v, int ply);
-Value value_from_tt(Value v, int ply, int r50c);
-void  update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
-void  update_quiet_histories(
-   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
+Value            value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
+Value            value_to_tt(Value v, int ply);
+Value            value_from_tt(Value v, int ply, int r50c);
+sf_noinline void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
+void             update_quiet_histories(
+              const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
 void update_all_stats(const Position& pos,
                       Stack*          ss,
                       Search::Worker& workerThread,
@@ -1892,19 +1892,23 @@ void update_all_stats(const Position& pos,
 
 // Updates the continuation histories for the move pairs formed by
 // the current move and the moves played in previous plies.
-void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
+template<bool InCheck>
+static sf_noinline void
+update_continuation_histories_impl(Stack* ss, Piece pc, Square to, int bonus) {
+
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1071}, {2, 753}, {3, 329}, {4, 539}, {5, 124}, {6, 434}}};
+
+    // Only update the first 2 continuation histories if we are in check
+    constexpr std::size_t N = InCheck ? 2 : conthist_bonuses.size();
 
     // Multipliers for positive history consistency
     constexpr int CMHCMultipliers[] = {96, 100, 100, 100, 115, 118, 129};
     int           positiveCount     = 0;
 
-    for (const auto [i, weight] : conthist_bonuses)
+    for (std::size_t k = 0; k < N; ++k)
     {
-        // Only update the first 2 continuation histories if we are in check
-        if (ss->inCheck && i > 2)
-            break;
+        const auto [i, weight] = conthist_bonuses[k];
 
         if (((ss - i)->currentMove).is_ok())
         {
@@ -1916,6 +1920,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             historyEntry << (bonus * weight * multiplier / 131072) + 73 * (i < 2);
         }
     }
+}
+
+sf_noinline void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
+    if (ss->inCheck)
+        update_continuation_histories_impl<true>(ss, pc, to, bonus);
+    else
+        update_continuation_histories_impl<false>(ss, pc, to, bonus);
 }
 
 // Updates move sorting heuristics


### PR DESCRIPTION
## Summary

Sibling of `update-conthist-templated-noinline` that applies `sf_noinline` **twice**: once on the templated `update_continuation_histories_impl` (same as the parent branch) and once on the dispatcher wrapper `update_continuation_histories`. Forces every caller to make a real CALL into the wrapper, which then tail-jumps to the chosen impl.

## Codegen

| Branch | Symbols | Wrapper | Sizes |
|---|---|---|---|
| master | inlined into 10 callers | n/a | inlined |
| update-conthist-templated-noinline | wrapper + impl<true> + impl<false> | inlined at each call site | 10 + 83 + 226 |
| update-conthist-tn2 (this) | wrapper + impl<true> + impl<false>, **wrapper out of line** | one shared symbol | 10 + 87 + 226 |

10 call sites all share one wrapper symbol at `0x14011e7f0`. Wrapper does cmp `ss->inCheck` then tail-jumps to impl<false> (`0x14011e810`) or impl<true> (`0x14011fbd0`).

## Bench

`2723949` byte-equal to master `1a882efc`.

## Test plan

- [x] Local PGO bench byte-equal to master
- [ ] Fishtest STC (normal bounds 0.0 / 2.0), submit after templated-noinline concludes