### PR TITLE
AVX-512-ICL outer-scan vectorization in partial_insertion_sort (bench-equal to master)

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,8 +19,13 @@
 #include "movepick.h"
 
 #include <cassert>
+#include <cstddef>
 #include <limits>
 #include <utility>
+
+#if defined(USE_AVX512ICL)
+    #include <immintrin.h>
+#endif
 
 #include "bitboard.h"
 #include "misc.h"
@@ -59,9 +64,37 @@ enum Stages {
 
 // Sort moves in descending order up to and including a given limit.
 // The order of moves smaller than the limit is left unspecified.
+// AVX-512-ICL vectorizes only the above-limit scan; inner shift is scalar.
 void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
-    for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+    ExtMove* sortedEnd = begin;
+
+#if defined(USE_AVX512ICL)
+    static_assert(sizeof(ExtMove) == 8 && offsetof(ExtMove, value) == 4,
+                  "AVX-512 path assumes ExtMove is 8 bytes with value in high 32 bits");
+    int N = (int) (end - begin);
+    // vpcmpge against limit per 8-element chunk; iterate set bits with lsb.
+    __m512i lim_v = _mm512_set1_epi64(limit);
+    int     off   = 1;
+    for (; off + 8 <= N; off += 8)
+    {
+        __m512i  data   = _mm512_loadu_si512((const void*) (begin + off));
+        __m512i  values = _mm512_srai_epi64(data, 32);
+        __mmask8 ge     = _mm512_cmpge_epi64_mask(values, lim_v);
+        while (ge)
+        {
+            int bit      = lsb(Bitboard(ge));
+            ge           = (__mmask8) (ge & (ge - 1));
+            ExtMove* p   = begin + off + bit;
+            ExtMove  tmp = *p, *q;
+            *p           = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
+            *q = tmp;
+        }
+    }
+    // Scalar tail.
+    for (ExtMove* p = begin + off; p < end; ++p)
         if (p->value >= limit)
         {
             ExtMove tmp = *p, *q;
@@ -70,6 +103,17 @@ void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
                 *q = *(q - 1);
             *q = tmp;
         }
+#else
+    for (ExtMove* p = begin + 1; p < end; ++p)
+        if (p->value >= limit)
+        {
+            ExtMove tmp = *p, *q;
+            *p          = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
+            *q = tmp;
+        }
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Vectorizes only the above-limit scan in `partial_insertion_sort` on AVX-512-ICL builds. Inner displacement-and-shift logic is master's scalar code, unchanged.

- Per 8-element chunk: `vpsra` extracts the high-32-bit value field, `vpcmpge` against the limit yields an 8-bit mask, iterate set bits with `tzcnt` and run master's exact inner loop per match.
- Scalar tail handles residual positions (< 8 elements).
- Non-ICL builds use master's scalar code unchanged via `#else`.

## Bench validation

| Build | ARCH | Bench |
|---|---|---:|
| HP (Intel Alder Lake-H, AVX-VNNI scalar) | x86-64-avxvnni | 2723949 |
| hw2 (AMD Zen4, AVX-512-ICL SIMD) | x86-64-avx512icl | 2723949 |
| master 1a882efc | any | 2723949 |

Bench is byte-identical to master on every arch by construction. The cached chunk values used for the SIMD mask are safe because master's algorithm only mutates positions <= sortedEnd < p, never the future-position slots already scanned.

## Background

This is one of two follow-ups to #(closed) `partial-sort-long-avx512` (test 69f12a78 +1.27 Elo on ICL-only fleet, test 69f1c0cd -10.86 Elo on non-ICL fleet) which combined SIMD with an algorithmic change. Splitting into orthogonal branches:

- This PR: master-compatible algorithm, SIMD speedup on ICL only, no risk on non-ICL.
- Sibling PR `partial-sort-stable-partition-avx512`: orthogonal algorithm change with bench-equal SIMD partition.

## Test plan

- [x] HP local PGO build with `ARCH=x86-64-avxvnni`, bench 2723949
- [x] hw2 PGO build with `ARCH=x86-64-avx512icl`, bench 2723949
- [ ] Fishtest STC normal SPRT to measure ICL-only Elo gain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Accelerated move evaluation processing on systems with advanced processor instruction set support. The optimization is hardware-aware and automatically adapts to available capabilities. Full backward compatibility is maintained—legacy systems continue functioning identically with no performance degradation or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->