### PR TITLE
Compact bijective LowPlyHistory packing into 4160 slots

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -134,9 +134,55 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: ply x compact bijective move packing into 4160 slots.
+// NORMAL keeps (from << 6) | to in [0, 4096), preserving per-pass cache-line
+// reuse. Non-NORMAL is bucketed by side-to-move into two 32-slot lines.
+constexpr std::size_t LOW_PLY_NORMAL_SLOTS = 4096;
+constexpr std::size_t LOW_PLY_COLOR_SLOTS  = 32;  // one cache line per color
+constexpr std::size_t LOW_PLY_MOVE_SLOTS   = LOW_PLY_NORMAL_SLOTS + 2 * LOW_PLY_COLOR_SLOTS;
+
+inline std::size_t low_ply_move_index(Move m) {
+    const std::uint32_t r     = m.raw();
+    const std::uint32_t type  = (r >> 14) & 3u;
+    const std::uint32_t low12 = r & 0xFFFu;
+
+    if (type == 0)  // NORMAL: ~99% of accesses, locality-preserving fast path
+        return low12;
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+
+    // Side-to-move: 0 = white, 1 = black. PROMOTION-from is on rank 7 for
+    // white (bit 5 = 1) and rank 2 for black (bit 5 = 0); CASTLING-from is
+    // E1 for white (bit 5 = 0) and E8 for black (bit 5 = 1). The two types
+    // therefore use opposite polarities of the same bit.
+    const std::uint32_t bit5  = from >> 5;
+    const std::uint32_t color = (type == 1) ? (1u - bit5) : bit5;
+    const std::uint32_t base  = LOW_PLY_NORMAL_SLOTS + (color << 5);
+
+    if (type == 1)  // PROMOTION: 8 files * 3 promo pieces = 24 entries per color
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        // QUIETS movegen never emits QUEEN promotions; that case would collide
+        // with the CASTLING bucket at file*3 + 3.
+        assert(promo < 3u && "QUEEN promotion must not reach LowPlyHistory");
+        const std::uint32_t file = from & 7u;
+        return base + file * 3u + promo;  // [base + 0, base + 24)
+    }
+
+    if (type == 3)  // CASTLING: 2 entries per color (queenside, kingside)
+    {
+        // Rook is encoded in `to`, king in `from`; comparing their files
+        // gives the side bit and stays correct under Chess960 placements.
+        const std::uint32_t to       = r & 0x3Fu;
+        const std::uint32_t side_bit = std::uint32_t((to & 7u) > (from & 7u));
+        return base + 24u + side_bit;  // [base + 24, base + 26)
+    }
+
+    assert(false && "EN_PASSANT must not reach LowPlyHistory");
+    return 0;
+}
+
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, LOW_PLY_MOVE_SLOTS>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][low_ply_move_index(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][low_ply_move_index(move)] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
## Summary

Compact bijective packing of `LowPlyHistory`'s move dimension into 4160 slots
(down from master's 65,536). NORMAL moves keep the full `(from << 6) | to`
layout in `[0, 4096)`, preserving master's per-pass cache-line reuse exactly.
Non-NORMAL moves (PROMOTION + CASTLING) are bucketed by side-to-move into
two 32-slot regions (one cache line each): white at `[4096, 4128)`, black at
`[4128, 4160)`. Per-worker LowPly footprint drops from 640 KiB to 40.6 KiB
(15.8x reduction).

## Why this packing

Empirical instrumentation of `score<QUIETS>` at low ply (ply < 5) across
STC, STC SMP, and LTC self-play measured per-pass cache-line counts:

- master: 8.35 mean lines/pass
- lowply-320k: 8.35 (identical to master)
- lowply-hashed-tagfree-b13: 26.30 (3.15x scatter)

Master and k320 are at the floor of achievable lines/pass; b13's
multiplicative perfect hash scatters by design. This branch inherits the
master/k320 NORMAL layout exactly, plus a frequency-aware tail bucketing
that places all of one side's PROMOTION + CASTLING traffic on a single
cache line.

Per-cell read/write profiling confirmed:
- top-128 hot raws are 100% NORMAL across every TC (PROMOTION never
  appears)
- the 4096-slot NORMAL table holds ~99% of access volume
- the entire 40.6 KiB footprint fits in L1, eliminating cache-residency
  concerns

## Bench

2723949 (byte-equal to master 1a882efc, expected since the index function
is a bijection on the QUIETS-phase reachable universe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned low-ply move-history indexing to be more compact and efficient.
  * Improves early-game move ordering and stability by changing how short-term move history is recorded.
  * Reduces memory footprint for low-ply history buckets while preserving existing scoring behavior for other histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->