### PR TITLE
Hoist LowPly row pointer out of update_quiet_histories

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -134,9 +134,58 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: ply x compact bijective move packing into 4160 slots.
+// NORMAL keeps (from << 6) | to in [0, 4096), preserving per-pass cache-line
+// reuse. Non-NORMAL is bucketed by side-to-move into two 32-slot lines.
+constexpr std::size_t LOW_PLY_NORMAL_SLOTS = 4096;
+constexpr std::size_t LOW_PLY_COLOR_SLOTS  = 32;  // one cache line per color
+constexpr std::size_t LOW_PLY_MOVE_SLOTS   = LOW_PLY_NORMAL_SLOTS + 2 * LOW_PLY_COLOR_SLOTS;
+
+inline std::size_t low_ply_move_index(Move m) {
+    const std::uint32_t r     = m.raw();
+    const std::uint32_t type  = (r >> 14) & 3u;
+    const std::uint32_t low12 = r & 0xFFFu;
+
+    if (type == 0)  // NORMAL: ~99% of accesses, locality-preserving fast path
+        return low12;
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+
+    // Side-to-move: 0 = white, 1 = black. PROMOTION-from is on rank 7 for
+    // white (bit 5 = 1) and rank 2 for black (bit 5 = 0); CASTLING-from is
+    // E1 for white (bit 5 = 0) and E8 for black (bit 5 = 1). The two types
+    // therefore use opposite polarities of the same bit.
+    const std::uint32_t bit5  = from >> 5;
+    const std::uint32_t color = (type == 1) ? (1u - bit5) : bit5;
+    const std::uint32_t base  = LOW_PLY_NORMAL_SLOTS + (color << 5);
+
+    if (type == 1)  // PROMOTION: 8 files * 3 promo pieces = 24 entries per color
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        // QUIETS movegen never emits QUEEN promotions; that case would collide
+        // with the CASTLING bucket at file*3 + 3.
+        assert(promo < 3u && "QUEEN promotion must not reach LowPlyHistory");
+        const std::uint32_t file = from & 7u;
+        return base + file * 3u + promo;  // [base + 0, base + 24)
+    }
+
+    if (type == 3)  // CASTLING: 2 entries per color (queenside, kingside)
+    {
+        // Rook is encoded in `to`, king in `from`; comparing their files
+        // gives the side bit and stays correct under Chess960 placements.
+        const std::uint32_t to       = r & 0x3Fu;
+        const std::uint32_t side_bit = std::uint32_t((to & 7u) > (from & 7u));
+        return base + 24u + side_bit;  // [base + 24, base + 26)
+    }
+
+    assert(false && "EN_PASSANT must not reach LowPlyHistory");
+    return 0;
+}
+
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, LOW_PLY_MOVE_SLOTS>;
+
+// LowPlyHistory bonus scale: bonus * LOWPLY_BONUS_NUMERATOR / 1024.
+constexpr unsigned LOWPLY_BONUS_NUMERATOR = 682;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][low_ply_move_index(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -805,8 +805,13 @@ Value Search::Worker::search(
         {
             // Bonus for a quiet ttMove that fails high
             if (!ttCapture)
-                update_quiet_histories(pos, ss, *this, ttData.move,
-                                       std::min(119 * depth - 74, 855));
+            {
+                const int bonus_qh = std::min(119 * depth - 74, 855);
+                update_quiet_histories(pos, ss, *this, ttData.move, bonus_qh);
+                if (ss->ply < LOW_PLY_HISTORY_SIZE)
+                    lowPlyHistory[ss->ply][low_ply_move_index(ttData.move)]
+                      << bonus_qh * int(LOWPLY_BONUS_NUMERATOR) / 1024;
+            }
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount < 4 && !priorCapture)
@@ -1867,6 +1872,23 @@ void update_all_stats(const Position& pos,
             actualMalus = actualMalus * 977 / 1024;
             update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
         }
+
+        // Apply LowPlyHistory writes in a separate loop with the row pointer
+        // hoisted: ss->ply is loop-invariant.
+        if (ss->ply < LOW_PLY_HISTORY_SIZE)
+        {
+            auto& lpRow = workerThread.lowPlyHistory[ss->ply];
+            lpRow[low_ply_move_index(bestMove)]
+              << bonus * 806 / 1024 * int(LOWPLY_BONUS_NUMERATOR) / 1024;
+
+            assert(malus >= 0);
+            unsigned lpMalus = unsigned(malus) * 1113 / 1024;
+            for (Move move : quietsSearched)
+            {
+                lpMalus = lpMalus * 977 / 1024;
+                lpRow[low_ply_move_index(move)] << -int(lpMalus * LOWPLY_BONUS_NUMERATOR / 1024);
+            }
+        }
     }
     else
     {
@@ -1926,8 +1948,8 @@ void update_quiet_histories(
     Color us = pos.side_to_move();
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
-    if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+    // LowPlyHistory write hoisted to caller (see update_all_stats and the
+    // search<NonPV> ttMove path) so the row pointer is computed once per pass.
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Stacked on lowply-compact-bijective. Removes the LowPlyHistory write from
update_quiet_histories and lifts it to the callers (update_all_stats and
the search<NonPV> ttMove path) so the row pointer
workerThread.lowPlyHistory[ss->ply] is computed once per pass instead of
once per move. Adds a constexpr lowply_bonus_scale() helper to keep the
682/1024 factor in one place.

Bench: 2723949 (byte-equal to master 1a882efc at depths 13/20/21).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal move indexing and history table access patterns for early-game search performance.
  * Reorganized quiet-move statistics updates for improved efficiency in the search algorithm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->