### PR TITLE
AoS interleaved hot-set layout for lowply addressing

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -134,9 +134,17 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// Slot count for the freq-aware tiered LowPly layout.
+constexpr std::size_t LOW_PLY_FREQ_SLOTS = 4388;
+
+// Maps a quiet Move's raw() to a frequency-tiered LowPly slot. The tier
+// formula assumes QUIETS-phase movegen invariants (no EN_PASSANT; promotions
+// are KNIGHT/BISHOP/ROOK only, never QUEEN); calling with a non-quiet move
+// will assert in debug. sf_noinline keeps the tier dispatch out of the
+// call-site BTB.
+sf_noinline std::size_t low_ply_freq_index(Move m);
+
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, LOW_PLY_FREQ_SLOTS>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -18,14 +18,19 @@
 
 #include "movegen.h"
 
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
+#include "misc.h"
 #include "position.h"
+#include "types.h"
 
 #if defined(USE_AVX512ICL)
-    #include <array>
     #include <algorithm>
     #include <immintrin.h>
 #endif
@@ -284,6 +289,146 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+namespace {
+
+// 32-entry hot-set lookup for the highest-frequency Move::raw values observed
+// in QUIETS scoring. Greedy-fill multiply-shift hash; on hit, return the
+// precomputed slot directly and skip the tier dispatch. On miss, fall through
+// to the formula below. Tags and addresses generated offline from per-cell
+// access counters; for each fitted tag, the address equals the value the tier
+// formula below would return, so a hit is observationally indistinguishable
+// from running the formula.
+//
+// 29 of the top-32 raws fit (93.7% of top-32 access volume); 3 raws collide
+// and fall through to the formula. Empty slots use 0xFFFF, which never
+// matches a legal Move::raw() since CASTLING requires from != to.
+constexpr std::uint32_t HOTSET_HASH_M = 0xe858e7edu;
+constexpr unsigned int  HOTSET_HASH_S = 18u;
+
+// AoS interleaved layout: each (tag, addr) pair sits in 4 contiguous bytes,
+// so a hit reads a single 32-bit word and stays within one cache line.
+struct HotsetEntry {
+    std::uint16_t tag;
+    std::uint16_t addr;
+};
+static_assert(sizeof(HotsetEntry) == 4, "HotsetEntry must be 4 bytes for the AoS hot-set layout");
+
+struct alignas(128) HotsetTable {
+    std::array<HotsetEntry, 32> entries;
+};
+static_assert(sizeof(HotsetTable) == 128, "HotsetTable must be exactly 128 bytes");
+static_assert(alignof(HotsetTable) == 128, "HotsetTable must be aligned to 128 bytes");
+
+// 128 bytes total, aligned to 128 so the entire payload sits in two
+// consecutive 64-byte cache lines: entries 0-15 in line 0, 16-31 in line 1.
+// A hit touches only the line containing its idx.
+constexpr HotsetTable hotset = {{{
+  {0x0de7, 31},  {0x035d, 11}, {0x0459, 36},  {0x0c61, 19}, {0x018f, 152}, {0x039e, 13},
+  {0x0185, 145}, {0x0ba6, 91}, {0x0d6d, 26},  {0x0218, 1},  {0x03df, 15},  {0xffff, 0},
+  {0xffff, 0},   {0x0dae, 28}, {0x0259, 3},   {0x0355, 10}, {0x0c28, 16},  {0x0def, 30},
+  {0x0187, 151}, {0x0396, 12}, {0xffff, 0},   {0x0c69, 18}, {0x0d65, 27},  {0x0210, 0},
+  {0x03d7, 14},  {0x059e, 56}, {0x0fbf, 215}, {0x0da6, 29}, {0x0251, 2},   {0x0b24, 83},
+  {0x0e39, 167}, {0x0c20, 17},
+}}};
+
+}  // namespace
+
+// Frequency-aware LowPlyHistory address. A 32-entry hot-set covers ~12% of
+// total accesses with one multiply-shift hash + tag compare; misses fall
+// through to a tier-based formula reordered so the most common case (NORMAL
+// same-file pawn push) returns first.
+sf_noinline std::size_t low_ply_freq_index(Move m) {
+    const std::uint32_t r = m.raw();
+
+    // Hot-set lookup: greedy-filled top-frequency raws. On miss, fall through.
+    {
+        const std::uint32_t idx = ((r * HOTSET_HASH_M) >> HOTSET_HASH_S) & 0x1Fu;
+        const HotsetEntry   e   = hotset.entries[idx];
+        if (e.tag == r)
+            return e.addr;
+    }
+
+    // NORMAL move (top 2 bits of raw == 0): hot path.
+    if (r < 0x4000u)
+    {
+        const std::uint32_t from = (r >> 6) & 0x3Fu;
+        const std::uint32_t to   = r & 0x3Fu;
+        const std::uint32_t ff   = from & 7u;
+        const std::uint32_t tf   = to & 7u;
+
+        // Same-file => pawn-push candidate (tier 0 / tier 1).
+        if (ff == tf)
+        {
+            const std::uint32_t fr = from >> 3;
+            const std::uint32_t tr = to >> 3;
+
+            // White single push (fr in [1,5], tr=fr+1): tier 0 if fr=1, else tier 1.
+            if (fr >= 1u && fr <= 5u && tr == fr + 1u)
+            {
+                if (fr == 1u)
+                    return ff * 2u;
+                return 32u + ff * 4u + (fr - 2u);
+            }
+            // Black single push (fr in [2,6], tr=fr-1): tier 0 if fr=6, else tier 1.
+            if (fr >= 2u && fr <= 6u && tr + 1u == fr)
+            {
+                if (fr == 6u)
+                    return 16u + ff * 2u;
+                return 64u + ff * 4u + (fr - 2u);
+            }
+            // White init double push (fr=1, tr=3).
+            if (fr == 1u && tr == 3u)
+                return ff * 2u + 1u;
+            // Black init double push (fr=6, tr=4).
+            if (fr == 6u && tr == 4u)
+                return 16u + ff * 2u + 1u;
+        }
+
+        // Tier 2: back-rank chebyshev-1 single-step (king and adjacent piece moves).
+        const std::uint32_t fr = from >> 3;
+        if (fr == 0u || fr == 7u)
+        {
+            const std::uint32_t tr    = to >> 3;
+            const int           fdiff = static_cast<int>(tf) - static_cast<int>(ff);
+            const int           rdiff = static_cast<int>(tr) - static_cast<int>(fr);
+            if (fdiff >= -1 && fdiff <= 1 && rdiff >= -1 && rdiff <= 1
+                && (fdiff != 0 || rdiff != 0))
+            {
+                const std::uint32_t color = fr >> 2;
+                const std::uint32_t dest  = static_cast<std::uint32_t>(fdiff + 1) * 3u
+                                         + static_cast<std::uint32_t>(rdiff + 1);
+                return 96u + color * 64u + ff * 8u + dest;
+            }
+        }
+
+        // Tier 3: rest of NORMAL with (from << 6) | to ordering.
+        return 224u + ((from << 6) | to);
+    }
+
+    const std::uint32_t type = (r >> 14) & 3u;
+    // PROMOTION: QUIETS-only invariant -> promo in {0,1,2} (queen goes via
+    // CAPTURES); file*3+promo packs into [0, 24). boardHalf = from>>5.
+    if (type == 1u)
+    {
+        const std::uint32_t from      = (r >> 6) & 0x3Fu;
+        const std::uint32_t promo     = (r >> 12) & 3u;
+        const std::uint32_t boardHalf = from >> 5;
+        const std::uint32_t file      = from & 7u;
+        assert(promo < 3u);
+        return 4320u + (boardHalf << 5) + file * 3u + promo;
+    }
+
+    // CASTLING (type=3): Chess960-safe side bit via file comparison. EN_PASSANT
+    // (type=2) is generated only by CAPTURES/EVASIONS/NON_EVASIONS movegen and
+    // never reaches this QUIETS-only path.
+    assert(type == 3u);
+    const std::uint32_t from  = (r >> 6) & 0x3Fu;
+    const std::uint32_t to    = r & 0x3Fu;
+    const std::uint32_t color = from >> 5;
+    const std::uint32_t side  = static_cast<std::uint32_t>((to & 7u) > (from & 7u));
+    return 4384u + color * 2u + side;
 }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][low_ply_freq_index(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][low_ply_freq_index(move)] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Same 32-entry hot-set lookup as #317 (lowply-freq-aware-hotset), but the table is laid out as an array-of-structs `HotsetEntry { uint16 tag; uint16 addr }[32]` instead of two parallel `uint16[32]` arrays. Each (tag, addr) pair sits in 4 contiguous bytes.

Critically, by reading the entry into a local copy (`const HotsetEntry e = hotset.entries[idx];`) GCC fuses the two member accesses into a **single 32-bit DWORD load**:

```
mov    eax, DWORD PTR [r8+rax*4]   ; ONE 32-bit load (low=tag, high=addr)
cmp    cx, ax                       ; compare low 16 bits to raw
je     .L4
.L4:
shr    eax, 0x10                    ; extract addr from high 16 bits
pop    rbx
ret
```

Without the local copy, GCC emits two separate 16-bit loads at offsets 0 and 2, costing two load-port micro-ops on hit instead of one.

Compared to the SoA layout in #317:
- Hit-path memory accesses: **1** vs 2.
- Cache lines touched per hit: **1** (the line containing the entry) vs 2 (one for tag, one for addr).
- Same 128-byte total table size, same `alignas(128)`, same hash, same 29/32 fitted raws (12.3% of total LowPlyHistory access volume covered).

Bench-byte-equal to master at depths 13/20/21 (2,723,949 / 59,354,652 / 101,103,302). Functionally identical to lowply-freq-aware-hotset; only the table layout and access pattern change.

Bench: 2723949