### PR TITLE
Thin inline gate with sf_noinline rare helper

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -134,9 +134,31 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: thin inlined gate hands all rare cases to a noinline helper.
+// Hot path is just tier 3 (mid-rank piece moves, ~70% of calls) with one
+// biased JCC and zero stack spills. Helper preserves the full 4-tier layout:
+// pawn pushes [0,96), king back-rank [96,224), NORMAL rest [224,4320),
+// PROMOTION [4320,4384), CASTLING [4384,4388).
+constexpr std::size_t LOW_PLY_FREQ_SLOTS = 4388;
+
+sf_noinline std::size_t low_ply_freq_index_rare(std::uint32_t r);
+
+sf_always_inline inline std::size_t low_ply_freq_index(Move m) {
+    const std::uint32_t r  = std::uint32_t(m.raw());
+    const std::uint32_t fr = (r >> 9) & 7u;
+    const std::uint32_t ff = (r >> 6) & 7u;
+    const std::uint32_t tf = r & 7u;
+
+    // 0xC3u = bits {0,1,6,7}: ranks 1-2 (pawn from-rank) and ranks 7-8 (back-rank king/promo).
+    const std::uint32_t cold = std::uint32_t(r >= 0x4000u) | std::uint32_t(ff == tf)
+                             | std::uint32_t(((1u << fr) & 0xC3u) != 0u);
+    if (cold)
+        return low_ply_freq_index_rare(r);
+
+    return 224u + (r & 0xFFFu);
+}
+
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, LOW_PLY_FREQ_SLOTS>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,9 +19,13 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
+#include "misc.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +288,72 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+// Cold helper for low_ply_freq_index. Handles all moves that fail the inline
+// gate: special types, same-file moves (pawn-push shape; also matches
+// non-pawn vertical moves), and back-rank source moves (king candidates).
+sf_noinline std::size_t low_ply_freq_index_rare(std::uint32_t r) {
+    if (r >= 0x4000u)
+    {
+        const std::uint32_t type  = (r >> 14) & 3u;
+        const std::uint32_t from  = (r >> 6) & 0x3Fu;
+        const std::uint32_t to    = r & 0x3Fu;
+        const std::uint32_t promo = (r >> 12) & 3u;
+        // half = rank >> 2: ranks 1-4 -> 0, ranks 5-8 -> 1 (not the WHITE/BLACK enum).
+        const std::uint32_t half  = from >> 5;
+        const std::uint32_t fromf = from & 7u;
+        const std::uint32_t tof   = to & 7u;
+        // Only underpromotions reach here: queen promotions are captures-stage
+        // moves and are filtered upstream from lowPlyHistory, so promo is in [0,2].
+        assert(promo != 3u);
+        if (type == 1u)
+            return 4320u + (half << 5) + fromf * 3u + promo;
+        const std::uint32_t side = std::uint32_t(tof > fromf);
+        return 4384u + half * 2u + side;
+    }
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t tf   = to & 7u;
+
+    if (ff == tf)
+    {
+        if (fr >= 1u && fr <= 5u && tr == fr + 1u)
+        {
+            if (fr == 1u)
+                return ff * 2u;
+            return 32u + ff * 4u + (fr - 2u);
+        }
+        if (fr >= 2u && fr <= 6u && tr + 1u == fr)
+        {
+            if (fr == 6u)
+                return 16u + ff * 2u;
+            return 64u + ff * 4u + (fr - 2u);
+        }
+        if (fr == 1u && tr == 3u)
+            return ff * 2u + 1u;
+        if (fr == 6u && tr == 4u)
+            return 16u + ff * 2u + 1u;
+    }
+
+    if (fr == 0u || fr == 7u)
+    {
+        const int fdiff = int(tf) - int(ff);
+        const int rdiff = int(tr) - int(fr);
+        if (std::uint32_t(fdiff + 1) <= 2u && std::uint32_t(rdiff + 1) <= 2u
+            && (fdiff != 0 || rdiff != 0))
+        {
+            const std::uint32_t color_k = fr >> 2;
+            const std::uint32_t dest    = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+            return 96u + color_k * 64u + ff * 8u + dest;
+        }
+    }
+
+    return 224u + (r & 0xFFFu);
 }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][low_ply_freq_index(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][low_ply_freq_index(move)] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured low-ply move history indexing to use a frequency-tiered scheme, improving early-search move ordering and lookup efficiency.
  * Adjusted how quiet-move histories are recorded and accessed at shallow plies for more consistent scoring.

* **Chores**
  * Added compiler hints to control inlining behavior for better performance stability across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->