### PR TITLE
Frequency-aware mainHistory layout with cached slot

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,11 +128,76 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// ButterflyHistory: freq-aware mainHistory with split-mask pawn slots.
+// Init pushes (fr in {1,6}) and continuations (fr in {2..5}) computed by
+// parallel expressions selected via mask blend; king-class chebyshev=1 and
+// NORMAL fallback follow. NORMAL hot path branchless; cold tail handles
+// PROMOTION/CASTLING/EN_PASSANT.
+//
+// Slot layout (per color slice; total 4930 slots):
+//   [0, 32)        Tier 0  NORMAL initial-rank pawn pushes
+//   [32, 96)       Tier 1  NORMAL continuation single-pushes
+//   [96, 608)      Tier 2  NORMAL chebyshev=1 from any rank (king-class)
+//   [608, 4704)    Tier 3  NORMAL fallback, (from << 6) | to ordering
+//   [4704, 4768)   Tier 4  PROMOTION
+//   [4768, 4896)   Tier 5  CASTLING (DFRC-safe)
+//   [4896, 4928)   Tier 6  EN_PASSANT
+//   [4928, 4930)   unused (former sentinels; never reached at call sites)
+constexpr int MAINHIST_FREQ_SIZE = 4930;
+
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r);
+
+sf_always_inline inline std::size_t main_hist_freq_index(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return main_hist_freq_index_special(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t tf   = to & 7u;
+
+    const std::uint32_t tier3 = 608u + (r & 0xFFFu);
+
+    constexpr std::uint64_t PAWN_MASK = 0x00305028140a0c00ULL;
+    const std::uint32_t     same_file = std::uint32_t(((from ^ to) & 7u) == 0u);
+    const std::uint32_t pawn_hit  = same_file & std::uint32_t((PAWN_MASK >> (fr * 8u + tr)) & 1u);
+    const std::uint32_t pawn_mask = std::uint32_t(0u) - pawn_hit;
+
+    // pawn_color: 0=white (tr>=fr, moves up), 1=black (tr<fr, moves down).
+    // Move-geometry inferred (matches WHITE/BLACK semantics for legal pawn pushes).
+    const std::uint32_t pawn_color = std::uint32_t(tr < fr);
+    // is_init: 1 iff fr in {1, 6} (pawn home rank). 0x42 = bits 1 and 6 set.
+    const std::uint32_t is_init   = std::uint32_t((0x42u >> fr) & 1u);
+    const std::uint32_t init_mask = std::uint32_t(0u) - is_init;
+
+    // is_double: 1 iff |tr - fr| == 2 (pawn double push). Equivalent to
+    // ((tr ^ fr) & 3) == 2 on the valid (fr, tr) tuples in PAWN_MASK.
+    const std::uint32_t is_double = std::uint32_t(((tr ^ fr) & 3u) == 2u);
+    const std::uint32_t init_slot = (pawn_color << 4u) + (ff << 1u) + is_double;
+    const std::uint32_t cont_slot = 32u + (pawn_color << 5u) + (ff << 2u) + (fr - 2u);
+    const std::uint32_t pawn_slot = (init_slot & init_mask) | (cont_slot & ~init_mask);
+
+    // King-class chebyshev=1 (any rank).
+    const int           fdiff     = int(tf) - int(ff);
+    const int           rdiff     = int(tr) - int(fr);
+    const std::uint32_t fdiff_ok  = std::uint32_t(std::uint32_t(fdiff + 1) <= 2u);
+    const std::uint32_t rdiff_ok  = std::uint32_t(std::uint32_t(rdiff + 1) <= 2u);
+    const std::uint32_t not_null  = std::uint32_t((fdiff != 0) | (rdiff != 0));
+    const std::uint32_t king_hit  = fdiff_ok & rdiff_ok & not_null;
+    const std::uint32_t king_mask = std::uint32_t(0u) - king_hit;
+    const std::uint32_t pos       = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+    const std::uint32_t dest      = pos - std::uint32_t(pos > 3u);
+    const std::uint32_t king_slot = 96u + fr * 64u + ff * 8u + dest;
+
+    std::uint32_t s = (king_slot & king_mask) | (tier3 & ~king_mask);
+    s               = (pawn_slot & pawn_mask) | (s & ~pawn_mask);
+    return std::size_t(s);
+}
+
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, MAINHIST_FREQ_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,9 +19,13 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
+#include "misc.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +288,41 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+// Cold tail of main_hist_freq_index. Only entered for non-NORMAL move types
+// (PROMOTION, EN_PASSANT, CASTLING) since the hot path's `r >= 0x4000u` gate
+// catches those. Sentinels (raw=0, raw=65) are NORMAL-typed and route through
+// the inline path; the call sites in movepick/search are guarded upstream by
+// is_ok() so sentinels never reach mainHistory access.
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r) {
+    // Precondition from the inline hot gate: only non-NORMAL types reach here.
+    // Move::none() (raw=0) and Move::null() (raw=65) are NORMAL-typed and stay
+    // on the inline path; they cannot land in this cold tail.
+    assert(r >= 0x4000u);
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    // half = from >> 5 splits ranks 0-3 (0) vs 4-7 (1). Matches WHITE/BLACK for
+    // CASTLING; reversed for PROMOTION (white promotes from rank 6 -> half=1).
+    // Used as a bijection bit only.
+    const std::uint32_t half = from >> 5;
+
+    if (type == 1u)
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        return 4704u + (half << 5) + ff * 4u + promo;
+    }
+    if (type == 3u)
+        return 4768u + half * 64u + ff * 8u + tf;
+
+    // EN_PASSANT (type == 2): from rank 4 (white) or rank 3 (black).
+    const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+    const std::uint32_t dir     = std::uint32_t(tf > ff);
+    return 4896u + ep_half * 16u + tf * 2u + dir;
 }
 
 }  // namespace Stockfish

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>  // IWYU pragma: keep
 #include <cstddef>
+#include <cstdint>
 
 #include "types.h"
 
@@ -36,15 +37,29 @@ enum GenType {
     LEGAL
 };
 
-struct ExtMove: public Move {
-    int value;
+// Sentinel marking an uncomputed freq slot in ExtMove::freq_slot,
+// Stack::currentSlot, and MovePicker::lastSlot. Outside the valid slot
+// range [0, MAINHIST_FREQ_SIZE); reading this value at a cached read
+// site is a logic error caught by the asserts there.
+constexpr std::uint16_t NO_FREQ_SLOT = 0xFFFFu;
 
-    void operator=(Move m) { data = m.raw(); }
+// freq_slot caches the freq-aware mainHistory slot from MovePicker::score<>().
+// Reuses the 2-byte slot between Move::data and value that alignment would
+// otherwise leave empty; sizeof(ExtMove) stays at 8 bytes (static_assert below).
+struct ExtMove: public Move {
+    std::uint16_t freq_slot;
+    int           value;
+
+    void operator=(Move m) {
+        data      = m.raw();
+        freq_slot = NO_FREQ_SLOT;
+    }
 
     // Inhibit unwanted implicit conversions to Move
     // with an ambiguity that yields to a compile error.
     operator float() const = delete;
 };
+static_assert(sizeof(ExtMove) == 8, "ExtMove must remain 8 bytes");
 
 inline bool operator<(const ExtMove& f, const ExtMove& s) { return f.value < s.value; }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -157,8 +157,13 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         else if constexpr (Type == QUIETS)
         {
+            // Cache the freq-aware mainHistory slot in the ExtMove for reuse at the
+            // search-loop sites that read mainHistory for this same move.
+            const std::size_t freqSlot = main_hist_freq_index(m);
+            m.freq_slot                = std::uint16_t(freqSlot);
+
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][freqSlot];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -184,7 +189,11 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+            {
+                const std::size_t freqSlot = main_hist_freq_index(m);
+                m.freq_slot                = std::uint16_t(freqSlot);
+                m.value = (*mainHistory)[us][freqSlot] + (*continuationHistory[0])[pc][to];
+            }
         }
     }
     return it;
@@ -197,8 +206,12 @@ Move MovePicker::select(Pred filter) {
 
     for (; cur < endCur; ++cur)
         if (*cur != ttMove && filter())
+        {
+            lastFreqSlot = cur->freq_slot;
             return *cur++;
+        }
 
+    lastFreqSlot = NO_FREQ_SLOT;
     return Move::none();
 }
 
@@ -217,6 +230,7 @@ top:
     case QSEARCH_TT :
     case PROBCUT_TT :
         ++stage;
+        lastFreqSlot = std::uint16_t(main_hist_freq_index(ttMove));
         return ttMove;
 
     case CAPTURE_INIT :

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,6 +19,8 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
+#include <cstdint>
+
 #include "history.h"
 #include "movegen.h"
 #include "types.h"
@@ -48,8 +50,9 @@ class MovePicker {
                const SharedHistories*,
                int);
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
-    Move next_move();
-    void skip_quiet_moves();
+    Move          next_move();
+    std::uint16_t current_freq_slot() const { return lastFreqSlot; }
+    void          skip_quiet_moves();
 
    private:
     template<typename Pred>
@@ -71,7 +74,8 @@ class MovePicker {
     int                          threshold;
     Depth                        depth;
     int                          ply;
-    bool                         skipQuiets = false;
+    bool                         skipQuiets   = false;
+    std::uint16_t                lastFreqSlot = NO_FREQ_SLOT;  // freq slot of last emitted move
     ExtMove                      moves[MAX_MOVES];
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < MAINHIST_FREQ_SIZE; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -593,7 +593,8 @@ void Search::Worker::do_move(
 
     if (ss != nullptr)
     {
-        ss->currentMove = move;
+        ss->currentMove     = move;
+        ss->currentFreqSlot = std::uint16_t(main_hist_freq_index(move));
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -604,6 +605,7 @@ void Search::Worker::do_move(
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
+    ss->currentFreqSlot               = NO_FREQ_SLOT;
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
     ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
 }
@@ -898,7 +900,10 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        assert((ss - 1)->currentFreqSlot != NO_FREQ_SLOT);
+        assert((ss - 1)->currentFreqSlot
+               == std::uint16_t(main_hist_freq_index((ss - 1)->currentMove)));
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1126,7 +1131,9 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                assert(mp.current_freq_slot() != NO_FREQ_SLOT);
+                assert(mp.current_freq_slot() == std::uint16_t(main_hist_freq_index(move)));
+                history += 71 * mainHistory[us][mp.current_freq_slot()] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1253,9 +1260,13 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+        {
+            assert(mp.current_freq_slot() != NO_FREQ_SLOT);
+            assert(mp.current_freq_slot() == std::uint16_t(main_hist_freq_index(move)));
+            ss->statScore = 2 * mainHistory[us][mp.current_freq_slot()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
+        }
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
@@ -1475,7 +1486,10 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        assert((ss - 1)->currentFreqSlot != NO_FREQ_SLOT);
+        assert((ss - 1)->currentFreqSlot
+               == std::uint16_t(main_hist_freq_index((ss - 1)->currentMove)));
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1924,7 +1938,8 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][main_hist_freq_index(move)]
+      << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
         workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;

--- a/src/search.h
+++ b/src/search.h
@@ -108,16 +108,18 @@ struct Stack {
     CorrectionHistory<PieceTo>* continuationCorrectionHistory;
     int                         ply;
     Move                        currentMove;
-    Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
-    bool                        inCheck;
-    bool                        ttPv;
-    bool                        ttHit;
-    bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
+    std::uint16_t
+          currentFreqSlot;  // cached main_hist_freq_index(currentMove); NO_FREQ_SLOT if unset
+    Move  excludedMove;
+    Value staticEval;
+    int   statScore;
+    int   moveCount;
+    bool  inCheck;
+    bool  ttPv;
+    bool  ttHit;
+    bool  followPV;
+    int   cutoffCnt;
+    int   reduction;
 };
 
 


### PR DESCRIPTION
Builds on mainhist-freq-aware (PR #332) by caching the per-move freq slot in `ExtMove::freq_slot` (existing 2-byte padding, no struct growth) and `Stack::currentSlot`.

Search-loop and prev-move read sites use the cached slot via `mp.current_slot()` and `(ss-1)->currentSlot` instead of recomputing `main_hist_freq_index` each time. The function is computed once per move (in score()) and once per descent (in do_move()) instead of at every read site.

Bench-byte-equal to master and to mainhist-freq-aware:
- depth 13: 2,723,949
- depth 20: 59,354,652
- depth 21: 101,103,302

Same search behavior; differs only in cycle count. Estimated ~5-20% NPS gain at STC over the un-cached freq-aware due to eliminating recompute at 4 sites x 5-15 calls/node.

Cache scope is mainhist-only. Lowply is excluded because its freq function is cheaper (~5cy vs ~10cy), it has no recompute sites outside the score() expression, and lowply/mainhist have different optimal sortings. See research/freq-aware-indexing-architectural-review.md.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Introduces frequency-aware move indexing and a fixed-size main history to improve move ordering consistency and search efficiency.
* **New Features**
  * Caches a compact frequency slot with each move and propagates it through the move picker and search stack to speed lookups.
* **Refactor**
  * Internal layout changes across move and search data structures to support the new frequency-aware indexing and caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->