### PR TITLE
Frequency-aware mainHistory layout, sf_noinline outer and inner

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,11 +128,30 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// ButterflyHistory: frequency-aware indexed mainHistory with split-mask pawn
+// slot computation. Init pawn pushes (first-row source: fr in {1,6}) at
+// [0,32) and continuation pawn pushes (fr in {2..5}) at [32,96) are computed
+// by separate slot expressions selected via mask blend rather than a unified
+// variable-shift chain. King-class chebyshev=1 (any rank) at [96,608); NORMAL
+// rest at [608,4704); PROMOTION/CASTLING/EN_PASSANT in cold tail. Hot path is
+// fully branchless inside NORMAL: a single conditional branch (the cold gate)
+// routes non-NORMAL types to a small cold tail.
+//
+// Slot layout (per color slice; total 4930 slots):
+//   [0, 32)        Tier 0  NORMAL initial-rank pawn pushes
+//   [32, 96)       Tier 1  NORMAL continuation single-pushes
+//   [96, 608)      Tier 2  NORMAL chebyshev=1 from any rank (king-class)
+//   [608, 4704)    Tier 3  NORMAL fallback, (from << 6) | to ordering
+//   [4704, 4768)   Tier 4  PROMOTION
+//   [4768, 4896)   Tier 5  CASTLING (DFRC-safe)
+//   [4896, 4928)   Tier 6  EN_PASSANT
+//   [4928, 4930)   unused (former sentinels; never reached at call sites)
+constexpr int MAINHIST_FREQ_SIZE = 4930;
+
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r);
+sf_noinline std::size_t main_hist_freq_index(Move m);
+
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, MAINHIST_FREQ_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -339,6 +339,13 @@ sf_noinline std::size_t main_hist_freq_index(Move m) {
 
     const std::uint32_t tier3 = 608u + (r & 0xFFFu);
 
+    // PAWN_MASK encodes the 12 legal NORMAL pawn pushes as a 64-bit bitmap
+    // indexed by (fr * 8 + tr): bit set iff a pawn can move from rank fr to
+    // rank tr in a single NORMAL move (init single + double pushes from
+    // ranks 1 and 6, continuation single pushes from ranks 2..5 in either
+    // direction). Set bits at positions {10,11,17,19,26,28,35,37,44,46,52,53}
+    // = 0x305028140a0c00. Captures and promotions are routed elsewhere; this
+    // mask only matters for same-file moves which can only be pawn pushes.
     constexpr std::uint64_t PAWN_MASK = 0x00305028140a0c00ULL;
     const std::uint32_t     same_file = std::uint32_t(((from ^ to) & 7u) == 0u);
     const std::uint32_t pawn_hit  = same_file & std::uint32_t((PAWN_MASK >> (fr * 8u + tr)) & 1u);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,9 +19,13 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
+#include "misc.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +288,85 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+// Cold tail of main_hist_freq_index. Only entered for non-NORMAL move types
+// (PROMOTION, EN_PASSANT, CASTLING) since the hot path's `r >= 0x4000u` gate
+// catches those. Sentinels (raw=0, raw=65) are NORMAL-typed and route through
+// the inline path; the call sites in movepick/search are guarded upstream by
+// is_ok() so sentinels never reach mainHistory access.
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r) {
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    // half = from >> 5 splits ranks 0-3 (0) vs 4-7 (1). Matches WHITE/BLACK for
+    // CASTLING; reversed for PROMOTION (white promotes from rank 6 -> half=1).
+    // Used as a bijection bit only.
+    const std::uint32_t half = from >> 5;
+
+    if (type == 1u)
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        return 4704u + (half << 5) + ff * 4u + promo;
+    }
+    if (type == 3u)
+        return 4768u + half * 64u + ff * 8u + tf;
+
+    // EN_PASSANT (type == 2): from rank 4 (white) or rank 3 (black).
+    const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+    const std::uint32_t dir     = std::uint32_t(tf > ff);
+    return 4896u + ep_half * 16u + tf * 2u + dir;
+}
+
+// Frequency-aware mainHistory index. Both inner and outer marked sf_noinline
+// to force fully out-of-line codegen at every call site, isolating
+// "function-call-cost only" from "inline-bloat".
+// See research/mainhist-fa-attr-and-cache-experiments.md.
+sf_noinline std::size_t main_hist_freq_index(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return main_hist_freq_index_special(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t tf   = to & 7u;
+
+    const std::uint32_t tier3 = 608u + (r & 0xFFFu);
+
+    constexpr std::uint64_t PAWN_MASK = 0x00305028140a0c00ULL;
+    const std::uint32_t     same_file = std::uint32_t(((from ^ to) & 7u) == 0u);
+    const std::uint32_t pawn_hit  = same_file & std::uint32_t((PAWN_MASK >> (fr * 8u + tr)) & 1u);
+    const std::uint32_t pawn_mask = std::uint32_t(0u) - pawn_hit;
+
+    const std::uint32_t pawn_color = std::uint32_t(tr < fr);
+    const std::uint32_t is_init    = std::uint32_t((0x42u >> fr) & 1u);
+    const std::uint32_t init_mask  = std::uint32_t(0u) - is_init;
+
+    const std::uint32_t is_double = std::uint32_t(((tr ^ fr) & 3u) == 2u);
+    const std::uint32_t init_slot = (pawn_color << 4u) + (ff << 1u) + is_double;
+    const std::uint32_t cont_slot = 32u + (pawn_color << 5u) + (ff << 2u) + (fr - 2u);
+    const std::uint32_t pawn_slot = (init_slot & init_mask) | (cont_slot & ~init_mask);
+
+    const int           fdiff     = int(tf) - int(ff);
+    const int           rdiff     = int(tr) - int(fr);
+    const std::uint32_t fdiff_ok  = std::uint32_t(std::uint32_t(fdiff + 1) <= 2u);
+    const std::uint32_t rdiff_ok  = std::uint32_t(std::uint32_t(rdiff + 1) <= 2u);
+    const std::uint32_t not_null  = std::uint32_t((fdiff != 0) | (rdiff != 0));
+    const std::uint32_t king_hit  = fdiff_ok & rdiff_ok & not_null;
+    const std::uint32_t king_mask = std::uint32_t(0u) - king_hit;
+    const std::uint32_t pos       = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+    const std::uint32_t dest      = pos - std::uint32_t(pos > 3u);
+    const std::uint32_t king_slot = 96u + fr * 64u + ff * 8u + dest;
+
+    std::uint32_t s = (king_slot & king_mask) | (tier3 & ~king_mask);
+    s               = (pawn_slot & pawn_mask) | (s & ~pawn_mask);
+    return std::size_t(s);
 }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -158,7 +158,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         else if constexpr (Type == QUIETS)
         {
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][main_hist_freq_index(m)];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -184,7 +184,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value =
+                  (*mainHistory)[us][main_hist_freq_index(m)] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < MAINHIST_FREQ_SIZE; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -898,7 +898,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][main_hist_freq_index((ss - 1)->currentMove)] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1126,7 +1126,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][main_hist_freq_index(move)] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1253,7 +1253,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][main_hist_freq_index(move)]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1475,7 +1475,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][main_hist_freq_index((ss - 1)->currentMove)] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1924,7 +1924,8 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][main_hist_freq_index(move)]
+      << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
         workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;


### PR DESCRIPTION
Variant of mainhist-freq-aware where both inner and outer index functions are forced out-of-line via sf_noinline. Tests the function-call cost lever in isolation. PAWN_MASK constant appears exactly once in PGO disasm (vs 7 in mainhist-fa-no-attr where 6 sites were still inlined despite no keyword). 19 references to the function symbol = pure call form at every site. Bench byte-equal master.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized move history storage and indexing with frequency-aware bucketing to optimize memory layout and improve move evaluation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->