### PR TITLE
Frequency-aware continuationHistory inner Piece permutation

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -144,6 +144,43 @@ using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PI
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 
+// Frequency-aware continuationHistory inner permutation. Reorders the inner
+// Piece axis of PieceToHistory so the highest-volume piece codes (W_ROOK,
+// B_ROOK, W_KING, B_KING, ...) cluster at the lowest addresses inside each
+// 1.5 KiB PieceToHistory instance. Designed from the empirical 9-cell,
+// 134-blob, 670-billion-access conthist capture documented in
+// research/conthist-cell-counters.md. Bijective on the full 16-entry Piece
+// space, so every distinct chess piece code maps to a unique permuted slot
+// and bench-byte-equality is preserved when applied uniformly at every
+// inner conthist read/write site.
+//
+// Order (canonical aggregate ranking, hot to cold):
+//   W_ROOK, B_ROOK, W_KING, B_KING, W_QUEEN, B_QUEEN,
+//   W_PAWN, W_BISHOP, B_BISHOP, B_PAWN, W_KNIGHT, B_KNIGHT,
+//   NO_PIECE, [unused 7], [unused 8], [unused 15]
+alignas(64) inline constexpr std::array<std::uint8_t, PIECE_NB> CONT_HIST_PIECE_PERM = {
+  13,  //  0 NO_PIECE -> rank 14 (cold)
+  6,   //  1 W_PAWN   -> rank 7
+  10,  //  2 W_KNIGHT -> rank 11
+  7,   //  3 W_BISHOP -> rank 8
+  0,   //  4 W_ROOK   -> rank 1 (hottest)
+  4,   //  5 W_QUEEN  -> rank 5
+  2,   //  6 W_KING   -> rank 3
+  14,  //  7 unused   -> dead slot
+  15,  //  8 unused   -> dead slot
+  9,   //  9 B_PAWN   -> rank 10
+  11,  // 10 B_KNIGHT -> rank 12 (coldest realized)
+  8,   // 11 B_BISHOP -> rank 9
+  1,   // 12 B_ROOK   -> rank 2
+  5,   // 13 B_QUEEN  -> rank 6
+  3,   // 14 B_KING   -> rank 4
+  12   // 15 unused   -> dead slot
+};
+
+sf_always_inline inline Piece cont_hist_piece(Piece pc) {
+    return Piece(CONT_HIST_PIECE_PERM[std::uint32_t(pc) & 0xFu]);
+}
+
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
 // PieceToHistory instead of ButterflyBoards.

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -148,6 +148,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         const Square    from          = m.from_sq();
         const Square    to            = m.to_sq();
         const Piece     pc            = pos.moved_piece(m);
+        const Piece     chpc          = cont_hist_piece(pc);
         const PieceType pt            = type_of(pc);
         const Piece     capturedPiece = pos.piece_on(to);
 
@@ -160,11 +161,11 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             // histories
             m.value = 2 * (*mainHistory)[us][m.raw()];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
-            m.value += (*continuationHistory[0])[pc][to];
-            m.value += (*continuationHistory[1])[pc][to];
-            m.value += (*continuationHistory[2])[pc][to];
-            m.value += (*continuationHistory[3])[pc][to];
-            m.value += (*continuationHistory[5])[pc][to];
+            m.value += (*continuationHistory[0])[chpc][to];
+            m.value += (*continuationHistory[1])[chpc][to];
+            m.value += (*continuationHistory[2])[chpc][to];
+            m.value += (*continuationHistory[3])[chpc][to];
+            m.value += (*continuationHistory[5])[chpc][to];
 
             // bonus for checks
             m.value += ((pos.check_squares(pt) & to) && pos.see_ge(m, -75)) * 16384;
@@ -184,7 +185,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[chpc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1117,9 +1117,10 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
-                int dIndex  = std::min(int(depth), int(lmrDivisor.size())) - 1;
-                int history = (*contHist[0])[movedPiece][move.to_sq()]
-                            + (*contHist[1])[movedPiece][move.to_sq()]
+                int         dIndex  = std::min(int(depth), int(lmrDivisor.size())) - 1;
+                const Piece chMoved = cont_hist_piece(movedPiece);
+                int         history = (*contHist[0])[chMoved][move.to_sq()]
+                            + (*contHist[1])[chMoved][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
 
                 // Continuation history based pruning
@@ -1253,9 +1254,11 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
-                          + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()];
+        {
+            const Piece chMoved = cont_hist_piece(movedPiece);
+            ss->statScore = 2 * mainHistory[us][move.raw()] + (*contHist[0])[chMoved][move.to_sq()]
+                          + (*contHist[1])[chMoved][move.to_sq()];
+        }
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
@@ -1900,6 +1903,8 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     constexpr int CMHCMultipliers[] = {96, 100, 100, 100, 115, 118, 129};
     int           positiveCount     = 0;
 
+    const Piece chPc = cont_hist_piece(pc);
+
     for (const auto [i, weight] : conthist_bonuses)
     {
         // Only update the first 2 continuation histories if we are in check
@@ -1908,7 +1913,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
         if (((ss - i)->currentMove).is_ok())
         {
-            auto& historyEntry = (*(ss - i)->continuationHistory)[pc][to];
+            auto& historyEntry = (*(ss - i)->continuationHistory)[chPc][to];
             if (historyEntry > 0)
                 positiveCount++;
 


### PR DESCRIPTION
Stage B1 of the conthist freq-aware investigation. Reorders the inner Piece axis of PieceToHistory so the highest-volume piece codes (W_ROOK, B_ROOK, W_KING, B_KING, ...) cluster at the lowest addresses inside each 1.5 KiB PieceToHistory instance.

Designed from the 9-cell, 134-blob, 670-billion-access conthist capture (research/conthist-cell-counters.md). 16-entry rodata permutation, bijective on the full Piece space, applied at all 11 inner conthist read/write sites. Outer (parent_pc, parent_to) selecting which PieceToHistory pointer to use is unchanged.

Bench byte-equal master at depths 13/20/21.

Bench: 2723949