### PR TITLE
Frequency-aware continuationHistory inner Piece permutation (array-based)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -144,6 +144,49 @@ using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PI
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 
+// Frequency-aware continuationHistory permutation so that unusable pieces are
+// not mixed with the real ones.
+static_assert(PIECE_NB == 16, "CONT_HIST_PIECE_PERM mask assumes 16-entry Piece space");
+alignas(64) inline constexpr std::array<std::uint8_t, PIECE_NB> CONT_HIST_PIECE_PERM = {
+  13,  //  0 NO_PIECE -> slot 13 (cold)
+  6,   //  1 W_PAWN   -> slot 6
+  10,  //  2 W_KNIGHT -> slot 10
+  7,   //  3 W_BISHOP -> slot 7
+  0,   //  4 W_ROOK   -> slot 0  (hottest, multi-cell aggregate)
+  4,   //  5 W_QUEEN  -> slot 4
+  2,   //  6 W_KING   -> slot 2
+  14,  //  7 unused   -> dead slot
+  15,  //  8 unused   -> dead slot
+  9,   //  9 B_PAWN   -> slot 9
+  11,  // 10 B_KNIGHT -> slot 11 (coldest realized)
+  8,   // 11 B_BISHOP -> slot 8
+  1,   // 12 B_ROOK   -> slot 1
+  5,   // 13 B_QUEEN  -> slot 5
+  3,   // 14 B_KING   -> slot 3
+  12   // 15 unused   -> dead slot
+};
+
+// Compile-time bijection check: every value in [0, PIECE_NB) appears exactly once.
+static_assert(
+  [] {
+      bool seen[PIECE_NB] = {};
+      for (auto v : CONT_HIST_PIECE_PERM)
+      {
+          if (v >= PIECE_NB || seen[v])
+              return false;
+          seen[v] = true;
+      }
+      return true;
+  }(),
+  "CONT_HIST_PIECE_PERM must be a bijection on [0, PIECE_NB)");
+
+// Returns a permuted index, NOT a real chess piece. The result is for indexing
+// into PieceToHistory only and must never be passed to type_of() / color_of().
+sf_always_inline inline std::size_t cont_hist_piece_index(Piece pc) {
+    assert(unsigned(pc) < PIECE_NB);
+    return std::size_t(CONT_HIST_PIECE_PERM[unsigned(pc)]);
+}
+
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
 // PieceToHistory instead of ButterflyBoards.

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -157,14 +157,15 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         else if constexpr (Type == QUIETS)
         {
+            const std::size_t chPcIdx = cont_hist_piece_index(pc);
             // histories
             m.value = 2 * (*mainHistory)[us][m.raw()];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
-            m.value += (*continuationHistory[0])[pc][to];
-            m.value += (*continuationHistory[1])[pc][to];
-            m.value += (*continuationHistory[2])[pc][to];
-            m.value += (*continuationHistory[3])[pc][to];
-            m.value += (*continuationHistory[5])[pc][to];
+            m.value += (*continuationHistory[0])[chPcIdx][to];
+            m.value += (*continuationHistory[1])[chPcIdx][to];
+            m.value += (*continuationHistory[2])[chPcIdx][to];
+            m.value += (*continuationHistory[3])[chPcIdx][to];
+            m.value += (*continuationHistory[5])[chPcIdx][to];
 
             // bonus for checks
             m.value += ((pos.check_squares(pt) & to) && pos.see_ge(m, -75)) * 16384;
@@ -184,7 +185,11 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+            {
+                const std::size_t chPcIdx = cont_hist_piece_index(pc);
+
+                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[chPcIdx][to];
+            }
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1117,9 +1117,12 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
-                int dIndex  = std::min(int(depth), int(lmrDivisor.size())) - 1;
-                int history = (*contHist[0])[movedPiece][move.to_sq()]
-                            + (*contHist[1])[movedPiece][move.to_sq()]
+                int dIndex = std::min(int(depth), int(lmrDivisor.size())) - 1;
+
+                const std::size_t chMovedIdx = cont_hist_piece_index(movedPiece);
+
+                int history = (*contHist[0])[chMovedIdx][move.to_sq()]
+                            + (*contHist[1])[chMovedIdx][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
 
                 // Continuation history based pruning
@@ -1253,9 +1256,13 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
+        {
+            const std::size_t chMovedIdx = cont_hist_piece_index(movedPiece);
+
             ss->statScore = 2 * mainHistory[us][move.raw()]
-                          + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()];
+                          + (*contHist[0])[chMovedIdx][move.to_sq()]
+                          + (*contHist[1])[chMovedIdx][move.to_sq()];
+        }
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
@@ -1900,6 +1907,8 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     constexpr int CMHCMultipliers[] = {96, 100, 100, 100, 115, 118, 129};
     int           positiveCount     = 0;
 
+    const std::size_t chPcIdx = cont_hist_piece_index(pc);
+
     for (const auto [i, weight] : conthist_bonuses)
     {
         // Only update the first 2 continuation histories if we are in check
@@ -1908,7 +1917,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
         if (((ss - i)->currentMove).is_ok())
         {
-            auto& historyEntry = (*(ss - i)->continuationHistory)[pc][to];
+            auto& historyEntry = (*(ss - i)->continuationHistory)[chPcIdx][to];
             if (historyEntry > 0)
                 positiveCount++;
 


### PR DESCRIPTION
Stage B1 of the conthist freq-aware investigation. Reorders the inner Piece axis of PieceToHistory using a 16-entry rodata permutation (array-based dispatch, ~2 cy). Highest-volume piece codes (W_ROOK, B_ROOK, W_KING, B_KING, ...) cluster at the lowest addresses inside each 1.5 KiB PieceToHistory instance. Designed from the empirical 9-cell, 134-blob, 670-billion-access conthist capture (research/conthist-cell-counters.md).

Renamed from conthist-freq-aware per user request, reserving the freq-aware name for an algorithmic-dispatch variant.

Bench byte-equal master at depths 13/20/21.

Bench: 2723949