### PR TITLE
Compact bijective LowPlyHistory with sf_always_inline outer plus sf_noinline cold tail

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -134,9 +134,24 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory: ply x compact bijective move packing into 4160 slots.
+// NORMAL keeps (from << 6) | to in [0, 4096), preserving per-pass cache-line
+// reuse. Non-NORMAL is bucketed by side-to-move into two 32-slot lines via
+// an out-of-line cold tail.
+constexpr std::size_t LOW_PLY_NORMAL_SLOTS = 4096;
+constexpr std::size_t LOW_PLY_COLOR_SLOTS  = 32;  // one cache line per color
+constexpr std::size_t LOW_PLY_MOVE_SLOTS   = LOW_PLY_NORMAL_SLOTS + 2 * LOW_PLY_COLOR_SLOTS;
+
+sf_noinline std::size_t low_ply_move_index_special(std::uint32_t r);
+
+sf_always_inline inline std::size_t low_ply_move_index(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return low_ply_move_index_special(r);
+    return std::size_t(r & 0xFFFu);
+}
+
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, LOW_PLY_MOVE_SLOTS>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -22,6 +22,7 @@
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +285,51 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+// Cold tail of low_ply_move_index. Only entered for non-NORMAL move types
+// (PROMOTION, CASTLING; EN_PASSANT must not reach LowPlyHistory). Each color
+// gets a 32-slot bucket starting at LOW_PLY_NORMAL_SLOTS.
+sf_noinline std::size_t low_ply_move_index_special(std::uint32_t r) {
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+
+    // type == 0u (NORMAL) is filtered by the hot-path gate; reaching this
+    // function with type == 0 is a logic error.
+    assert(type != 0u);
+
+    // Side-to-move: 0 = white, 1 = black. PROMOTION-from is on rank 7 for
+    // white (bit 5 = 1) and rank 2 for black (bit 5 = 0); CASTLING-from is
+    // E1 for white (bit 5 = 0) and E8 for black (bit 5 = 1). The two types
+    // therefore use opposite polarities of the same bit.
+    const std::uint32_t bit5  = from >> 5;
+    const std::uint32_t color = (type == 1u) ? (1u - bit5) : bit5;
+    const std::uint32_t base  = LOW_PLY_NORMAL_SLOTS + (color << 5);
+
+    // Order by typical VLTC frequency (120+1.2, 1T, initial position):
+    //   CASTLING   87.54% of non-NORMAL calls
+    //   PROMOTION  12.46%
+    //   EN_PASSANT must not reach LowPlyHistory (asserted)
+    if (type == 3u)
+    {  // CASTLING: 2 entries per color (queenside, kingside)
+        // Rook is encoded in `to`, king in `from`; comparing their files
+        // gives the side bit and stays correct under Chess960 placements.
+        const std::uint32_t to       = r & 0x3Fu;
+        const std::uint32_t side_bit = std::uint32_t((to & 7u) > (from & 7u));
+        return base + 24u + side_bit;  // [base + 24, base + 26)
+    }
+    if (type == 1u)
+    {  // PROMOTION: 8 files * 3 promo pieces = 24 entries per color
+        const std::uint32_t promo = (r >> 12) & 3u;
+        // QUIETS movegen never emits QUEEN promotions; that case would collide
+        // with the CASTLING bucket at file*3 + 3.
+        assert(promo < 3u && "QUEEN promotion must not reach LowPlyHistory");
+        const std::uint32_t file = from & 7u;
+        return base + file * 3u + promo;  // [base + 0, base + 24)
+    }
+
+    assert(false && "EN_PASSANT must not reach LowPlyHistory");
+    return 0;
 }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,7 +176,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][low_ply_move_index(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1927,7 +1927,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][low_ply_move_index(move)] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal move history indexing scheme from a simple layout to a more compact encoding, reducing memory footprint and improving search efficiency.
  * Added compiler directives to enhance function inlining optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->