### PR TITLE
AVX-512ICL 32-element stable insertion sort for quiets

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -22,6 +22,10 @@
 #include <limits>
 #include <utility>
 
+#if defined(USE_AVX512ICL)
+    #include <immintrin.h>
+#endif
+
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
@@ -62,6 +66,127 @@ enum Stages {
 void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+        if (p->value >= limit)
+        {
+            ExtMove tmp = *p, *q;
+            *p          = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
+            *q = tmp;
+        }
+}
+
+#if defined(USE_AVX512ICL)
+
+// Splat the move bits and value of an ExtMove into all lanes of two registers.
+void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
+    move  = _mm512_set1_epi32(m.raw());
+    value = _mm512_set1_epi32(m.value);
+}
+
+// Stable descending insertion sorter for up to 32 ExtMoves; lo holds the
+// 16 largest, hi holds the next 16, with cross-register propagation lo[15] -> hi[0].
+struct SimdSorter {
+    static constexpr int MAX_ELEMENTS = 32;
+    __m512i              sorted_values_lo, sorted_moves_lo;
+    __m512i              sorted_values_hi, sorted_moves_hi;
+
+    explicit SimdSorter(const ExtMove& first) {
+        splat_extmove(first, sorted_moves_lo, sorted_values_lo);
+        sorted_values_lo = _mm512_mask_set1_epi32(sorted_values_lo, __mmask16(0xFFFE),
+                                                  std::numeric_limits<int>::min());
+        sorted_values_hi = _mm512_set1_epi32(std::numeric_limits<int>::min());
+        sorted_moves_hi  = _mm512_setzero_si512();
+    }
+
+    void insert(const ExtMove& m) {
+        __m512i move, value;
+        splat_extmove(m, move, value);
+
+        const __mmask16 to_right_lo = _mm512_cmplt_epi32_mask(sorted_values_lo, value);
+        const __mmask16 to_right_hi = _mm512_cmplt_epi32_mask(sorted_values_hi, value);
+
+        // Extract OLD lo[15] before the lo expand overwrites it.
+        const __m512i idx15  = _mm512_set1_epi32(15);
+        const __m512i lo15_v = _mm512_permutexvar_epi32(idx15, sorted_values_lo);
+        const __m512i lo15_m = _mm512_permutexvar_epi32(idx15, sorted_moves_lo);
+
+        // Bit 15 of to_right_lo: 1 = value displaces lo[15] (v_in_lo), 0 = value
+        // goes to hi (lo unchanged); blend mask flips that bit so lane 0 picks
+        // lo15 in v_in_lo case and value in v_in_hi case.
+        const __mmask16 v_in_lo_bit = _kshiftri_mask16(to_right_lo, 15);
+        const __mmask16 blend_mask  = _kxor_mask16(__mmask16(0xFFFF), v_in_lo_bit);
+        const __m512i   src_v_hi    = _mm512_mask_blend_epi32(blend_mask, lo15_v, value);
+        const __m512i   src_m_hi    = _mm512_mask_blend_epi32(blend_mask, lo15_m, move);
+
+        const __mmask16 expand_lo = _kadd_mask16(to_right_lo, __mmask16(-1));
+        const __mmask16 expand_hi = _kadd_mask16(to_right_hi, __mmask16(-1));
+
+        sorted_values_hi = _mm512_mask_expand_epi32(src_v_hi, expand_hi, sorted_values_hi);
+        sorted_moves_hi  = _mm512_mask_expand_epi32(src_m_hi, expand_hi, sorted_moves_hi);
+        sorted_values_lo = _mm512_mask_expand_epi32(value, expand_lo, sorted_values_lo);
+        sorted_moves_lo  = _mm512_mask_expand_epi32(move, expand_lo, sorted_moves_lo);
+    }
+
+    void write_sorted(ExtMove* dst, int count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        const __m512i interleave_lo =
+          _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+        const __m512i interleave_hi =
+          _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+        if (count > 0)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_lo, interleave_lo, sorted_values_lo);
+            _mm512_mask_storeu_epi64(dst, __mmask8((1U << std::min(count, 8)) - 1), v);
+        }
+        if (count > 8)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_lo, interleave_hi, sorted_values_lo);
+            _mm512_mask_storeu_epi64(dst + 8, __mmask8((1U << std::min(count - 8, 8)) - 1), v);
+        }
+        if (count > 16)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_hi, interleave_lo, sorted_values_hi);
+            _mm512_mask_storeu_epi64(dst + 16, __mmask8((1U << std::min(count - 16, 8)) - 1), v);
+        }
+        if (count > 24)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_hi, interleave_hi, sorted_values_hi);
+            _mm512_mask_storeu_epi64(dst + 24, __mmask8((1U << std::min(count - 24, 8)) - 1), v);
+        }
+    }
+};
+
+#endif
+
+// Descending sort for the QUIETS site; SIMD prefix is byte-equivalent to the
+// scalar loop and falls through to the scalar tail past MAX_ELEMENTS.
+void partial_insertion_sort_long(ExtMove* begin, ExtMove* end, int limit) {
+
+    ExtMove* sortedEnd = begin;
+    ExtMove* p         = begin + 1;
+
+#if defined(USE_AVX512ICL)
+    if (p < end)
+    {
+        SimdSorter sorter(*begin);
+        for (; p < end; ++p)
+            if (p->value >= limit)
+            {
+                if (sortedEnd - begin + 1 >= SimdSorter::MAX_ELEMENTS)
+                    break;
+                sorter.insert(*p);
+                *p = *++sortedEnd;
+            }
+        sorter.write_sorted(begin, int(sortedEnd - begin + 1));
+    }
+#endif
+
+    for (; p < end; ++p)
         if (p->value >= limit)
         {
             ExtMove tmp = *p, *q;
@@ -251,7 +376,7 @@ top:
 
             endCur = endGenerated = score<QUIETS>(ml);
 
-            partial_insertion_sort(cur, endCur, -3560 * depth);
+            partial_insertion_sort_long(cur, endCur, -3560 * depth);
         }
 
         ++stage;


### PR DESCRIPTION
## Summary

Generalizes the 16-lane SIMD sorter from `quiets-sort-icl-stable` (PR sibling)
to 32 lanes at the QUIETS sort site in `MovePicker::next_move()`. The 32
sorted positions are split across two ZMM-pair register banks (lo holds
0..15, hi holds 16..31). Each insert runs lo and hi expansions in parallel;
any element displaced from `lo[15]` propagates into `hi[0]` via a branchless
cross-register shift on the kmask domain.

Bench-equal to master byte-for-byte. CAPTURES and EVASIONS continue to
call the unchanged scalar `partial_insertion_sort`. AVX-512ICL-gated;
non-ICL builds use the unchanged scalar path.

## Bench

Bench: 2723949

Identical to master `1a882efc` and to parent `quiets-sort-icl-stable`. The
SIMD prefix is byte-equivalent to the scalar loop (same descending order,
same tiebreak for equal values, same residual below-limit suffix).

## Per-call cost vs `quiets-sort-icl-stable`

At QUIET_INIT the K distribution has mean ~9-10 and p99 = 32-63. The 16-lane
parent covers K up to 16 with SIMD and falls through to scalar past that;
this branch covers K up to 32 with SIMD. Per-insert cycle cost is +1 cy vs
the parent on Intel ICL+ (10 vs 9), recovered when K > 16. Crossover at
K ~ 18 on Intel ICL+, K ~ 20 on Zen 4.

Full analysis: see the diff's .md in stockfish-nnue/diffs/quiets-sort-icl-32.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved move-ordering performance for faster engine decision-making, with additional speedups on CPUs supporting advanced SIMD instructions. Enhances sorting of candidate moves during quiet-move selection to reduce evaluation time and improve overall responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->