### PR TITLE
AVX-512ICL 32-element stable insertion sort for quiets isolated via sf_noinline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,15 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    // do nothing for other compilers
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -22,6 +22,10 @@
 #include <limits>
 #include <utility>
 
+#if defined(USE_AVX512ICL)
+    #include <immintrin.h>
+#endif
+
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
@@ -71,6 +75,134 @@ void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
             *q = tmp;
         }
 }
+
+#if defined(USE_AVX512ICL)
+
+// Splat the move bits and value of an ExtMove into all lanes of two registers.
+void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
+    move  = _mm512_set1_epi32(m.raw());
+    value = _mm512_set1_epi32(m.value);
+}
+
+// Stable descending insertion sorter for up to 32 ExtMoves; lo holds the
+// 16 largest, hi holds the next 16, with cross-register propagation lo[15] -> hi[0].
+struct SimdSorter {
+    static constexpr int MAX_ELEMENTS = 32;
+    __m512i              sorted_values_lo, sorted_moves_lo;
+    __m512i              sorted_values_hi, sorted_moves_hi;
+
+    explicit SimdSorter(const ExtMove& first) {
+        splat_extmove(first, sorted_moves_lo, sorted_values_lo);
+        sorted_values_lo = _mm512_mask_set1_epi32(sorted_values_lo, __mmask16(0xFFFE),
+                                                  std::numeric_limits<int>::min());
+        sorted_values_hi = _mm512_set1_epi32(std::numeric_limits<int>::min());
+        sorted_moves_hi  = _mm512_setzero_si512();
+    }
+
+    void insert(const ExtMove& m) {
+        __m512i move, value;
+        splat_extmove(m, move, value);
+
+        const __mmask16 to_right_lo = _mm512_cmplt_epi32_mask(sorted_values_lo, value);
+        const __mmask16 to_right_hi = _mm512_cmplt_epi32_mask(sorted_values_hi, value);
+
+        // Extract OLD lo[15] before the lo expand overwrites it.
+        const __m512i idx15  = _mm512_set1_epi32(15);
+        const __m512i lo15_v = _mm512_permutexvar_epi32(idx15, sorted_values_lo);
+        const __m512i lo15_m = _mm512_permutexvar_epi32(idx15, sorted_moves_lo);
+
+        // Bit 15 of to_right_lo: 1 = v displaces lo[15] (v_in_lo), 0 = v in hi;
+        // blend mask flips it so lane 0 of src_v_hi picks lo15 vs v accordingly.
+        const __mmask16 v_in_lo_bit = _kshiftri_mask16(to_right_lo, 15);
+        const __mmask16 blend_mask  = _kxor_mask16(__mmask16(0xFFFF), v_in_lo_bit);
+        const __m512i   src_v_hi    = _mm512_mask_blend_epi32(blend_mask, lo15_v, value);
+        const __m512i   src_m_hi    = _mm512_mask_blend_epi32(blend_mask, lo15_m, move);
+
+        const __mmask16 expand_lo = _kadd_mask16(to_right_lo, __mmask16(-1));
+        const __mmask16 expand_hi = _kadd_mask16(to_right_hi, __mmask16(-1));
+
+        sorted_values_hi = _mm512_mask_expand_epi32(src_v_hi, expand_hi, sorted_values_hi);
+        sorted_moves_hi  = _mm512_mask_expand_epi32(src_m_hi, expand_hi, sorted_moves_hi);
+        sorted_values_lo = _mm512_mask_expand_epi32(value, expand_lo, sorted_values_lo);
+        sorted_moves_lo  = _mm512_mask_expand_epi32(move, expand_lo, sorted_moves_lo);
+    }
+
+    void write_sorted(ExtMove* dst, int count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        const __m512i interleave_lo =
+          _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+        const __m512i interleave_hi =
+          _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+        if (count > 0)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_lo, interleave_lo, sorted_values_lo);
+            _mm512_mask_storeu_epi64(dst, __mmask8((1U << std::min(count, 8)) - 1), v);
+        }
+        if (count > 8)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_lo, interleave_hi, sorted_values_lo);
+            _mm512_mask_storeu_epi64(dst + 8, __mmask8((1U << std::min(count - 8, 8)) - 1), v);
+        }
+        if (count > 16)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_hi, interleave_lo, sorted_values_hi);
+            _mm512_mask_storeu_epi64(dst + 16, __mmask8((1U << std::min(count - 16, 8)) - 1), v);
+        }
+        if (count > 24)
+        {
+            const __m512i v =
+              _mm512_permutex2var_epi32(sorted_moves_hi, interleave_hi, sorted_values_hi);
+            _mm512_mask_storeu_epi64(dst + 24, __mmask8((1U << std::min(count - 24, 8)) - 1), v);
+        }
+    }
+};
+
+#endif
+
+// Descending sort for the QUIETS site; SIMD prefix is byte-equivalent to the
+// scalar loop and falls through to the scalar tail past MAX_ELEMENTS.
+#if defined(USE_AVX512ICL)
+    #define SF_SORT_LONG_NOINLINE sf_noinline
+#else
+    #define SF_SORT_LONG_NOINLINE
+#endif
+
+SF_SORT_LONG_NOINLINE void partial_insertion_sort_long(ExtMove* begin, ExtMove* end, int limit) {
+
+    ExtMove* sortedEnd = begin;
+    ExtMove* p         = begin + 1;
+
+#if defined(USE_AVX512ICL)
+    if (p < end)
+    {
+        SimdSorter sorter(*begin);
+        for (; p < end; ++p)
+            if (p->value >= limit)
+            {
+                if (sortedEnd - begin + 1 >= SimdSorter::MAX_ELEMENTS)
+                    break;
+                sorter.insert(*p);
+                *p = *++sortedEnd;
+            }
+        sorter.write_sorted(begin, int(sortedEnd - begin + 1));
+    }
+#endif
+
+    for (; p < end; ++p)
+        if (p->value >= limit)
+        {
+            ExtMove tmp = *p, *q;
+            *p          = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
+            *q = tmp;
+        }
+}
+
+#undef SF_SORT_LONG_NOINLINE
 
 }  // namespace
 
@@ -251,7 +383,7 @@ top:
 
             endCur = endGenerated = score<QUIETS>(ml);
 
-            partial_insertion_sort(cur, endCur, -3560 * depth);
+            partial_insertion_sort_long(cur, endCur, -3560 * depth);
         }
 
         ++stage;


### PR DESCRIPTION
## Summary

Sibling of #344 that adds an `sf_noinline` macro to `misc.h` (mirroring the
existing `sf_always_inline`) and applies it conditionally to
`partial_insertion_sort_long`. Under `USE_AVX512ICL` this extracts the SIMD
sort body and the unrolled scan loop out of `MovePicker::next_move()` into a
separate function. Under non-AVX-512ICL builds the attribute is empty and the
function inlines normally as a thin scalar wrapper.

Bench-equal to master byte-for-byte (2723949). Same SIMD primitive set as
#344, same stability proof; only the inlining boundary moves.

## Why noinline the OUTER, not the inner

This was the central design question. Three variants were compiled and
disassembled before choosing.

next_move instruction count (PGO, x86-64-avx512icl, mingw GCC 15.2.0):

- Master: 1626
- #344 (no noinline, SIMD inlined into next_move): 2049
- noinline on inner SimdSorter::insert: 2139 (worse, plus per-call ZMM spill)
- This branch (noinline on partial_insertion_sort_long): 1598 (BELOW master)

Win64 / SysV ABI both make all of `xmm`/`ymm`/`zmm` caller-saved. The
SimdSorter holds 4 ZMM state registers across iterations. Putting noinline on
the inner function forces every call to spill those four ZMMs to the stack
struct and reload them, adding ~25 cy per insert (verified on disassembly,
artifacts in `scratchpad/stockfish-quiets-sort-icl-32-noinline-inner.{exe,asm}`).
That regression more than wipes out the SIMD gain.

Putting noinline on the outer function isolates the SIMD body into its own
function while preserving register-resident state inside that function:
SimdSorter::insert is still inlined 7 times within `partial_insertion_sort_long`,
the 4-ZMM state stays in `zmm0`/`zmm1`/`zmm2`/`zmm5` across all inserts.
Per-call cost is one `call` per QUIETS stage execution.

## Bench

Bench: 2723949

Identical to master `1a882efc` and to #344.

## Files modified

- `src/misc.h` (added `sf_noinline` macro, mirroring `sf_always_inline`)
- `src/movepick.cpp` (32-element SimdSorter + conditionally-applied
  `sf_noinline` on `partial_insertion_sort_long`)

Detailed disassembly comparison and per-variant cycle accounting in
stockfish-nnue at:

- `diffs/quiets-sort-icl-32-noinline.md`
- `research/quiets-sort-noinline-options.md`