### PR TITLE
AVX-512ICL 16-element sort for quiets via sf_noinline

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,15 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    // do nothing for other compilers
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -22,6 +22,10 @@
 #include <limits>
 #include <utility>
 
+#if defined(USE_AVX512ICL)
+    #include <immintrin.h>
+#endif
+
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
@@ -71,6 +75,102 @@ void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
             *q = tmp;
         }
 }
+
+#if defined(USE_AVX512ICL)
+
+// Splat the move bits and value of an ExtMove into all lanes of two registers.
+void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
+    move  = _mm512_set1_epi32(m.raw());
+    value = _mm512_set1_epi32(m.value);
+}
+
+// Stable descending insertion sorter for up to 16 ExtMoves. Single-register
+// state keeps the per-insert cost at four SIMD ops on the critical path
+// (cmplt, kadd, two expand).
+struct SimdSorter {
+    static constexpr int MAX_ELEMENTS = 16;
+    __m512i              sortedValues, sortedMoves;
+
+    explicit SimdSorter(const ExtMove& first) {
+        splat_extmove(first, sortedMoves, sortedValues);
+        sortedValues = _mm512_mask_set1_epi32(sortedValues, ~1, std::numeric_limits<int>::min());
+    }
+
+    void insert(const ExtMove& m) {
+        __m512i move, value;
+        splat_extmove(m, move, value);
+
+        assert(m.value != std::numeric_limits<int>::min());
+        const __mmask16 expand =
+          _kadd_mask16(_mm512_cmplt_epi32_mask(sortedValues, value), __mmask16(-1));
+
+        sortedValues = _mm512_mask_expand_epi32(value, expand, sortedValues);
+        sortedMoves  = _mm512_mask_expand_epi32(move, expand, sortedMoves);
+    }
+
+    void write_sorted(ExtMove* dst, int count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        assert(count >= 1 && count <= MAX_ELEMENTS);
+
+        const __m512i interleave_lo =
+          _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+        const __m512i interleave_hi =
+          _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+
+        const __m512i v0 = _mm512_permutex2var_epi32(sortedMoves, interleave_lo, sortedValues);
+        const __m512i v1 = _mm512_permutex2var_epi32(sortedMoves, interleave_hi, sortedValues);
+
+        const __mmask8 m0 = __mmask8((1U << std::min(count, 8)) - 1);
+        const __mmask8 m1 = __mmask8((1U << std::max(std::min(count - 8, 8), 0)) - 1);
+
+        _mm512_mask_storeu_epi64(dst, m0, v0);
+        _mm512_mask_storeu_epi64(dst + 8, m1, v1);
+    }
+};
+
+#endif
+
+// Descending sort for the QUIETS site; SIMD prefix is byte-equivalent to the
+// scalar loop and falls through to the scalar tail past MAX_ELEMENTS.
+#if defined(USE_AVX512ICL)
+    #define SF_SORT_LONG_NOINLINE sf_noinline
+#else
+    #define SF_SORT_LONG_NOINLINE
+#endif
+
+SF_SORT_LONG_NOINLINE void partial_insertion_sort_long(ExtMove* begin, ExtMove* end, int limit) {
+
+    ExtMove* sortedEnd = begin;
+    ExtMove* p         = begin + 1;
+
+#if defined(USE_AVX512ICL)
+    if (p < end)
+    {
+        SimdSorter sorter(*begin);
+        for (; p < end; ++p)
+            if (p->value >= limit)
+            {
+                if (sortedEnd - begin + 1 >= SimdSorter::MAX_ELEMENTS)
+                    break;
+                sorter.insert(*p);
+                *p = *++sortedEnd;
+            }
+        sorter.write_sorted(begin, int(sortedEnd - begin + 1));
+    }
+#endif
+
+    for (; p < end; ++p)
+        if (p->value >= limit)
+        {
+            ExtMove tmp = *p, *q;
+            *p          = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
+            *q = tmp;
+        }
+}
+
+#undef SF_SORT_LONG_NOINLINE
 
 }  // namespace
 
@@ -251,7 +351,7 @@ top:
 
             endCur = endGenerated = score<QUIETS>(ml);
 
-            partial_insertion_sort(cur, endCur, -3560 * depth);
+            partial_insertion_sort_long(cur, endCur, -3560 * depth);
         }
 
         ++stage;


### PR DESCRIPTION
16-element AVX-512ICL stable insertion sort applied to QUIETS site only, isolated via sf_noinline outer wrapper. CAPTURES and EVASIONS keep master's small scalar partial_insertion_sort. Bench: 2723949 (byte-equal at depths 13 and 21).

Per-insert cost is 6 SIMD ops (single ZMM state, mirroring upstream PR #6768 by Anematode). At empirical mean K~24 the 16-element SIMD prefix plus master's scalar tail totals ~160 ops vs the parent x32 branch's ~384 ops. The sf_noinline outer wrapper extracts the SIMD body from MovePicker::next_move(), shrinking next_move below master's instruction count (1626 -> ~1598 in the x32 sibling).

See diffs/partial-sort-icl-x16-noinline.md for the full per-K op-count comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Performance**
* Optimized move-sorting algorithm with SIMD acceleration on supported processors for improved search efficiency

**Chores**
* Added compiler compatibility improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->