### PR TITLE
Hybrid AVX-512 partial-sort based on prior art by Anematode

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -516,6 +516,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
     #define sf_always_inline
 #endif
 
+#if defined(__GNUC__)
+    #define sf_noinline __attribute__((noinline))
+#elif defined(_MSC_VER)
+    #define sf_noinline __declspec(noinline)
+#else
+    #define sf_noinline
+#endif
+
 #if defined(__clang__)
     #define sf_assume(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -22,6 +22,10 @@
 #include <limits>
 #include <utility>
 
+#if defined(USE_AVX512ICL)
+    #include <immintrin.h>
+#endif
+
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
@@ -57,11 +61,140 @@ enum Stages {
 };
 
 
-// Sort moves in descending order up to and including a given limit.
-// The order of moves smaller than the limit is left unspecified.
-void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
-
+// Full insertion sort in descending order; used at CAPTURE/PROBCUT/QCAPTURE_INIT.
+inline sf_always_inline void insertion_sort(ExtMove* begin, ExtMove* end) {
     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+    {
+        ExtMove tmp = *p, *q;
+        *p          = *++sortedEnd;
+        for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+            *q = *(q - 1);
+        *q = tmp;
+    }
+}
+
+#if defined(USE_AVX512ICL)
+
+// Splat the move bits and value of an ExtMove into all lanes of two registers.
+void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
+    move  = _mm512_set1_epi32(m.raw());
+    value = _mm512_set1_epi32(m.value);
+}
+
+// 16-element stable descending insertion sorter; per-insert is cmplt + kadd + 2x expand.
+struct SimdSorter {
+    static constexpr int MAX_ELEMENTS = 16;
+    __m512i              sortedValues, sortedMoves;
+
+    explicit SimdSorter(const ExtMove& first) {
+        splat_extmove(first, sortedMoves, sortedValues);
+        sortedValues = _mm512_mask_set1_epi32(sortedValues, ~1, std::numeric_limits<int>::min());
+    }
+
+    void insert(const ExtMove& m) {
+        __m512i move, value;
+        splat_extmove(m, move, value);
+
+        assert(m.value != std::numeric_limits<int>::min());
+        const __mmask16 expand =
+          _kadd_mask16(_mm512_cmplt_epi32_mask(sortedValues, value), __mmask16(-1));
+
+        sortedValues = _mm512_mask_expand_epi32(value, expand, sortedValues);
+        sortedMoves  = _mm512_mask_expand_epi32(move, expand, sortedMoves);
+    }
+
+    // Drain with predicted branch; skips second store at count <= 8 (EVASIONS-typical).
+    void write_sorted_branchful(ExtMove* dst, int count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        assert(count >= 1 && count <= MAX_ELEMENTS);
+
+        auto write = [&](int offset, const __m512i indices) {
+            const __m512i extMoves = _mm512_permutex2var_epi32(sortedMoves, indices, sortedValues);
+            const std::ptrdiff_t storeCount = count - offset;
+            if (storeCount > 0)
+                _mm512_mask_storeu_epi64(dst + offset, (1U << storeCount) - 1, extMoves);
+        };
+        write(0, _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23));
+        write(8, _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31));
+    }
+
+    // Branchless drain; avoids the mispredict tax at QUIETS where count straddles 8.
+    void write_sorted_branchless(ExtMove* dst, int count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        assert(count >= 1 && count <= MAX_ELEMENTS);
+
+        const __m512i interleave_lo =
+          _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+        const __m512i interleave_hi =
+          _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+
+        const __m512i v0 = _mm512_permutex2var_epi32(sortedMoves, interleave_lo, sortedValues);
+        const __m512i v1 = _mm512_permutex2var_epi32(sortedMoves, interleave_hi, sortedValues);
+
+        const __mmask8 m0 = __mmask8((1U << std::min(count, 8)) - 1);
+        const __mmask8 m1 = __mmask8((1U << std::max(std::min(count - 8, 8), 0)) - 1);
+
+        _mm512_mask_storeu_epi64(dst, m0, v0);
+        _mm512_mask_storeu_epi64(dst + 8, m1, v1);
+    }
+};
+
+#endif
+
+// Full SIMD insertion sort for EVASION_INIT; inlined to keep per-call fixed cost low at N ~ 6.
+inline sf_always_inline void insertion_sort_medium(ExtMove* begin, ExtMove* end) {
+    // EVASIONS may be empty in checkmate edges; SIMD tolerates begin == end (harmless masked store).
+    assert(begin <= end);
+
+    ExtMove* sortedEnd = begin;
+    ExtMove* p         = begin + 1;
+
+#if defined(USE_AVX512ICL)
+    SimdSorter sorter(*begin);
+    for (; p < end; ++p)
+    {
+        if (sortedEnd - begin + 1 >= SimdSorter::MAX_ELEMENTS)
+            break;
+        sorter.insert(*p);
+        *p = *++sortedEnd;
+    }
+    sorter.write_sorted_branchful(begin, int(sortedEnd - begin + 1));
+#endif
+
+    for (; p < end; ++p)
+    {
+        ExtMove tmp = *p, *q;
+        *p          = *++sortedEnd;
+        for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+            *q = *(q - 1);
+        *q = tmp;
+    }
+}
+
+// Descending sort for QUIETS; SIMD prefix byte-equivalent to scalar, scalar tail past MAX_ELEMENTS.
+// Suffix "long" reflects that QUIETS mean N exceeds 16 here.
+sf_noinline void partial_insertion_sort_long(ExtMove* begin, ExtMove* end, int limit) {
+
+    // QUIETS may be empty in rare DFRC; SIMD tolerates begin == end (harmless masked store).
+    assert(begin <= end);
+
+    ExtMove* sortedEnd = begin;
+    ExtMove* p         = begin + 1;
+
+#if defined(USE_AVX512ICL)
+    SimdSorter sorter(*begin);
+    for (; p < end; ++p)
+        if (p->value >= limit)
+        {
+            if (sortedEnd - begin + 1 >= SimdSorter::MAX_ELEMENTS)
+                break;
+            sorter.insert(*p);
+            *p = *++sortedEnd;
+        }
+    sorter.write_sorted_branchless(begin, int(sortedEnd - begin + 1));
+#endif
+
+    for (; p < end; ++p)
         if (p->value >= limit)
         {
             ExtMove tmp = *p, *q;
@@ -227,7 +360,7 @@ top:
         cur = endBadCaptures = moves;
         endCur = endCaptures = score<CAPTURES>(ml);
 
-        partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
+        insertion_sort(cur, endCur);
         ++stage;
         goto top;
     }
@@ -251,7 +384,7 @@ top:
 
             endCur = endGenerated = score<QUIETS>(ml);
 
-            partial_insertion_sort(cur, endCur, -3560 * depth);
+            partial_insertion_sort_long(cur, endCur, -3560 * depth);
         }
 
         ++stage;
@@ -291,7 +424,7 @@ top:
         cur    = moves;
         endCur = endGenerated = score<EVASIONS>(ml);
 
-        partial_insertion_sort(cur, endCur, std::numeric_limits<int>::min());
+        insertion_sort_medium(cur, endCur);
         ++stage;
         [[fallthrough]];
     }


### PR DESCRIPTION
Hybrid AVX-512 partial-sort with three N-regime functions:

- insertion_sort (scalar): CAPTURE/PROBCUT/QCAPTURE_INIT, mean N 2-4
- insertion_sort_medium (inlined SIMD, branchful drain): EVASION_INIT, mean N 6.28
- partial_insertion_sort_long (sf_noinline SIMD, branchless drain, GCC auto-unrolls 4-way): QUIET_INIT, mean N 28.73

Based on prior art by Anematode (PR #6768, Faster movepick sorting on AVX512ICL). The 16-element SimdSorter struct, the per-insert cmplt+kadd+2x expand mechanism, and the interleaved drain pattern all derive from that work; this branch adds the per-N-regime function split.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized move ordering logic with AVX-512 SIMD support for improved performance on compatible processors.
  * Enhanced compiler compatibility with noinline behavior support across GCC, Clang, and MSVC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->