### PR TITLE
Hoist invariants out of update_all_stats quiet tail loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1858,14 +1858,33 @@ void update_all_stats(const Position& pos,
 
     if (!pos.capture_stage(bestMove))
     {
-        update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 806 / 1024);
+        const Color us      = pos.side_to_move();
+        auto&       mainRow = workerThread.mainHistory[us];
+        auto&       pawnRow = workerThread.sharedHistory.pawn_entry(pos);
+        const bool  lpOk    = ss->ply < LOW_PLY_HISTORY_SIZE;
+        auto* const lpRow   = lpOk ? &workerThread.lowPlyHistory[ss->ply] : nullptr;
+
+        {
+            const int b = bonus * 806 / 1024;
+            mainRow[bestMove.raw()] << b;
+            if (lpOk)
+                (*lpRow)[bestMove.raw()] << b * 682 / 1024;
+            update_continuation_histories(ss, movedPiece, bestMove.to_sq(), b * 894 / 1024);
+            pawnRow[movedPiece][bestMove.to_sq()] << b * (b > 0 ? 974 : 543) / 1024;
+        }
 
         int actualMalus = malus * 1113 / 1024;
-        // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
         {
-            actualMalus = actualMalus * 977 / 1024;
-            update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
+            actualMalus     = actualMalus * 977 / 1024;
+            const int    b  = -actualMalus;
+            const Piece  pc = pos.moved_piece(move);
+            const Square to = move.to_sq();
+            mainRow[move.raw()] << b;
+            if (lpOk)
+                (*lpRow)[move.raw()] << b * 682 / 1024;
+            update_continuation_histories(ss, pc, to, b * 894 / 1024);
+            pawnRow[pc][to] << b * 543 / 1024;
         }
     }
     else


### PR DESCRIPTION
Inlines update_quiet_histories into the bestMove and quietsSearched loop bodies of update_all_stats, with loop-invariants hoisted once before the loop:

- Color us = pos.side_to_move()
- mainHistory[us] row reference
- sharedHistory.pawn_entry(pos) row reference (avoids recomputing pos.pawn_key() and pawnHistSizeMinus1 on every iteration)
- ss->ply < LOW_PLY_HISTORY_SIZE test, with a hoisted lowPlyHistory[ss->ply] row pointer

Algorithmic identity preserved; bench unchanged at 2723949 (matches master). Per-quiet operations and scaling factors are identical to master (* 806 / 1024, * 682 / 1024, * 894 / 1024, * 974 / 1024 vs * 543 / 1024). The capture-stage bestMove branch and capturesSearched loop are unchanged.

The free function update_quiet_histories is retained for the TT-cutoff caller at search.cpp:808.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal search algorithm statistics handling for improved computational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->