### PR TITLE
Hoist pawn_entry row pointer out of score quiets loop

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -128,7 +128,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
     Color us = pos.side_to_move();
 
-    [[maybe_unused]] Bitboard threatByLesser[KING + 1];
+    [[maybe_unused]] Bitboard                                  threatByLesser[KING + 1];
+    [[maybe_unused]] decltype(&sharedHistory->pawn_entry(pos)) pawnRow = nullptr;
     if constexpr (Type == QUIETS)
     {
         threatByLesser[PAWN]   = 0;
@@ -137,6 +138,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
         threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
         threatByLesser[KING]  = 0;
+
+        pawnRow = &sharedHistory->pawn_entry(pos);
     }
 
     ExtMove* it = cur;
@@ -159,7 +162,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         {
             // histories
             m.value = 2 * (*mainHistory)[us][m.raw()];
-            m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
+            m.value += 2 * (*pawnRow)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];


### PR DESCRIPTION
Hoists sharedHistory->pawn_entry(pos) out of the per-move loop in MovePicker::score<QUIETS>. pawn_entry(pos) returns pawnHistory[pos.pawn_key() & pawnHistSizeMinus1]; pos is invariant across the score() call, so the row reference is computed once and reused as (*pawnRow)[pc][to] per move.

The hoist is gated by if constexpr (Type == QUIETS) because sharedHistory is uninitialized in the ProbCut MovePicker. A decltype-typed null pointer is declared at outer scope so the variable is visible inside the templated loop body without restructuring the three Type branches.

Bench: 2723949 (matches master).

Bench: 2723949