### PR TITLE
Narrow Stack ints and reorder fields

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -106,18 +106,18 @@ struct Stack {
     PVMoves*                    pv;
     PieceToHistory*             continuationHistory;
     CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
-    Move                        currentMove;
-    Move                        excludedMove;
     Value                       staticEval;
     int                         statScore;
-    int                         moveCount;
+    Move                        currentMove;
+    Move                        excludedMove;
+    std::int16_t                ply;
+    std::int16_t                reduction;
+    std::uint16_t               moveCount;
+    std::uint16_t               cutoffCnt;
     bool                        inCheck;
     bool                        ttPv;
     bool                        ttHit;
     bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
 };
 
 


### PR DESCRIPTION
Narrow four small int fields in Search::Stack to int16_t/uint16_t and reorder fields 64-bit-first then 32-bit then 16-bit then 8-bit. Stack size goes from 56 B to 48 B, representation-only.

- ply: int -> int16_t (MAX_PLY=246)
- reduction: int -> int16_t (range [-3, 245])
- moveCount: int -> uint16_t (MAX_MOVES=256)
- cutoffCnt: int -> uint16_t (small counter)

The three pointer fields stay 8 B absolute. statScore stays int (peak |x| ~74366). staticEval stays Value. Four bools stay 1 B each.

Per-Stack savings 56 B -> 48 B (-14%). Stack array (MAX_PLY+10=256 entries) goes 14336 B -> 12288 B (-2 KiB) per worker. Six-deep contHist walk at search.cpp:1027-1029 spans 6 cache lines on master (6x56=336 B) and at most 5 cache lines compressed (6x48=288 B).

Disassembly delta (avx512icl PGO, MSYS2 GCC 15.2.0):

| Function | Master | Branch | Delta |
|---|---:|---:|---:|
| search<NonPV> | 2928 | 2962 | +34 (+1.16%) |
| search<PV> | 2016 | 2022 | +6 (+0.30%) |
| qsearch<NonPV> | 1016 | 1008 | -8 (-0.79%) |

movzx/movsx widening for the narrowed fields is one fused-domain uop on Sapphire Rapids and Zen4, often eliminated in rename, so per-access cost is near-zero.

Bench: 2723949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structure layout and type definitions for improved memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->