### PR TITLE
mainhist-fa-pawn-fast-hoist-nocache: lossless single-formula pawn slot freq-aware mainHistory, no caching

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,11 +128,26 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// ButterflyHistory records how often quiet moves have been successful or
+// unsuccessful during the current search, and is used for reduction and
+// move ordering decisions. It uses 2 tables (one per color), indexed by
+// the from- and to-square coordinates of valid moves through a 4896-
+// entry move-to-slot map. Slot ranges are ordered by typical move
+// frequency in search: pawn pushes packed densely in [0, 128), other
+// normal moves in [128, 4224), and the rarer special-move classes in
+// descending frequency (castling, then promotion, then en passant).
+// See https://www.chessprogramming.org/Butterfly_Boards.
+// Slot layout (per color slice):
+//   [0, 128)     pawn pushes (96 used of 128)
+//   [128, 4224)  other normal moves (from-to bijection) (4096)
+//   [4224, 4352) castling (128)
+//   [4352, 4864) promotion (512)
+//   [4864, 4896) en passant (32)
+constexpr int MAINHIST_FREQ_SIZE = 4896;
+
+std::size_t main_hist_freq_index(Move m);
+
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, MAINHIST_FREQ_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,9 +19,12 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +287,77 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+namespace {
+
+// MoveType (types.h, bits 14-15 of Move::raw()): NORMAL=0, PROMOTION=1, EN_PASSANT=2, CASTLING=3.
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r) {
+    assert(r >= 0x4000u);
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t half = from >> 5;
+
+    // Frequency order: CASTLING > PROMOTION > EN_PASSANT.
+    if (type == 3u)  // CASTLING
+    {
+        const std::size_t slot = 4224u + half * 64u + ff * 8u + tf;
+        assert(slot >= 4224u && slot < 4352u);
+        return slot;
+    }
+    if (type == 1u)  // PROMOTION
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        const std::size_t   slot  = 4352u + (half << 8) + (ff << 5) + (tf << 2) + promo;
+        assert(slot >= 4352u && slot < 4864u);
+        return slot;
+    }
+    // EN_PASSANT (type == 2).
+    const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+    const std::uint32_t dir     = std::uint32_t(tf > ff);
+    const std::size_t   slot    = 4864u + ep_half * 16u + tf * 2u + dir;
+    assert(slot >= 4864u && slot < std::size_t(MAINHIST_FREQ_SIZE));
+    return slot;
+}
+
+}  // namespace
+
+std::size_t main_hist_freq_index(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return main_hist_freq_index_special(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t ff   = from & 7u;
+
+    constexpr std::uint64_t PAWN_MASK = 0x00305028140a0c00ULL;
+    const std::uint32_t     same_file = std::uint32_t(((from ^ to) & 7u) == 0u);
+    // (from & 0x38) is fr*8; (to >> 3) is tr; bits don't overlap.
+    const std::uint32_t pawn_pair = std::uint32_t((PAWN_MASK >> ((from & 0x38u) | (to >> 3u))) & 1u);
+    const std::uint32_t     pawn_hit  = same_file & pawn_pair;
+    const std::uint32_t     pawn_mask = std::uint32_t(0u) - pawn_hit;
+
+    const std::uint32_t pawn_color = std::uint32_t(tr < fr);
+    const std::uint32_t is_init    = std::uint32_t((0x42u >> fr) & 1u);
+    const std::uint32_t is_double  = std::uint32_t(((tr ^ fr) & 3u) == 2u);
+    const std::uint32_t idx        = is_init ? is_double : fr;
+    const std::uint32_t pawn_slot  = (pawn_color << 6) | (ff << 3) | idx;
+
+    const std::uint32_t tier2 = 128u + (r & 0xFFFu);
+
+    assert(!pawn_hit || pawn_slot < 128u);
+    assert(tier2 >= 128u && tier2 < 4224u);
+
+    const std::size_t result = std::size_t((pawn_slot & pawn_mask) | (tier2 & ~pawn_mask));
+    assert(result < std::size_t(MAINHIST_FREQ_SIZE));
+    return result;
 }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -158,7 +158,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         else if constexpr (Type == QUIETS)
         {
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][main_hist_freq_index(m)];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -184,7 +184,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value =
+                  (*mainHistory)[us][main_hist_freq_index(m)] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < MAINHIST_FREQ_SIZE; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -898,7 +898,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][main_hist_freq_index((ss - 1)->currentMove)] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1126,7 +1126,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][main_hist_freq_index(move)] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1253,7 +1253,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][main_hist_freq_index(move)]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1475,7 +1475,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][main_hist_freq_index((ss - 1)->currentMove)] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1924,7 +1924,8 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][main_hist_freq_index(move)]
+      << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
         workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;


### PR DESCRIPTION
## Summary

Lossless freq-aware mainHistory with single-formula pawn slot. Replaces master's
`(*mainHistory)[stm][m.raw()]` with `(*mainHistory)[stm][main_hist_freq_index(m)]`
at all 7 access sites (no caching; recompute at each site).

**Bench EQUAL to master at depth 13 (2,723,949) AND depth 20 (59,354,652)** -- proves
the index function is a true bijection on used moves (lossless permutation).

## Slot layout (4896 slots vs master's 65536 = 13x compression)

- `[0, 128)` Pawn slot = `(pawn_color << 6) | (ff << 3) | idx` where `idx = is_init ? is_double : fr`
- `[128, 4224)` NORMAL non-pawn-pattern: `128 + (from << 6) | to`
- `[4224, 4352)` CASTLING: `4224 + (half * 64) + (ff * 8) + tf` (DFRC-safe)
- `[4352, 4864)` PROMOTION: `4352 + (half << 8) + (ff << 5) + (tf << 2) + promo` (lossless on `tf`)
- `[4864, 4896)` EN_PASSANT: `4864 + (ep_half * 16) + (tf * 2) + dir`

## Bug fixed vs prior `mainhist-freq-aware*` branches

All four prior branches in this family used a cold-path encoding `4704 + (half << 5)
+ ff * 4 + promo` that drops `tf` -- collapsing forward-promote, capture-left-promote,
and capture-right-promote at the same `(from, promo)` to a SINGLE slot.

This branch encodes `tf` (`4352 + (half << 8) + (ff << 5) + (tf << 2) + promo`,
512 slots vs prior 64) -- lossless on capture-vs-forward distinction.

## Bench

- depth 13: **2,723,949 EQUAL master 1a882efc**
- depth 20: **59,354,652 EQUAL master 1a882efc**
- depth 13 NPS: 1,436,681 (Dell Sapphire Rapids w5-2445)
- depth 20 NPS: 1,429,922 (vs master 1,460,031; -2.1%)

## Companion branch

Sibling branch `mainhist-freq-aware-pawn-fast-hoist` adds ExtMove::freq_slot and
Stack::currentFreqSlot caches. Empirical comparison: this no-cache branch is
**+0.5% NPS faster** at depth 20. Cache mechanism's ALU overhead (~+5 cy/do_move
from instrumentation: 1.83:1 Stack write:read, 2.57:1 ExtMove write:read) exceeds
its potential i-cache savings.

## Files modified

- `src/history.h`, `src/misc.h`, `src/movegen.cpp`, `src/movepick.cpp`, `src/search.cpp`

Stack and ExtMove unchanged from master (no caching, no narrowing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal move history indexing system with a frequency-aware table structure to enhance move ordering efficiency during search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->