### PR TITLE
mainhist-freq-aware-pawn-fast-hoist: lossless freq-aware mainHistory with ExtMove + Stack caches atop stack-narrow-48b

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,11 +128,26 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// ButterflyHistory records how often quiet moves have been successful or
+// unsuccessful during the current search, and is used for reduction and
+// move ordering decisions. It uses 2 tables (one per color), indexed by
+// the from- and to-square coordinates of valid moves through a 4896-
+// entry move-to-slot map. Slot ranges are ordered by typical move
+// frequency in search: pawn pushes packed densely in [0, 128), other
+// normal moves in [128, 4224), and the rarer special-move classes in
+// descending frequency (castling, then promotion, then en passant).
+// See https://www.chessprogramming.org/Butterfly_Boards.
+// Slot layout (per color slice):
+//   [0, 128)     pawn pushes (96 used of 128)
+//   [128, 4224)  other normal moves (from-to bijection) (4096)
+//   [4224, 4352) castling (128)
+//   [4352, 4864) promotion (512)
+//   [4864, 4896) en passant (32)
+constexpr int MAINHIST_FREQ_SIZE = 4896;
+
+std::size_t main_hist_freq_index(Move m);
+
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, MAINHIST_FREQ_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,9 +19,12 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
@@ -284,6 +287,77 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
             ++cur;
 
     return moveList;
+}
+
+namespace {
+
+// MoveType (types.h, bits 14-15 of Move::raw()): NORMAL=0, PROMOTION=1, EN_PASSANT=2, CASTLING=3.
+sf_noinline std::size_t main_hist_freq_index_special(std::uint32_t r) {
+    assert(r >= 0x4000u);
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t half = from >> 5;
+
+    // Frequency order: CASTLING > PROMOTION > EN_PASSANT.
+    if (type == 3u)  // CASTLING
+    {
+        const std::size_t slot = 4224u + half * 64u + ff * 8u + tf;
+        assert(slot >= 4224u && slot < 4352u);
+        return slot;
+    }
+    if (type == 1u)  // PROMOTION
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        const std::size_t   slot  = 4352u + (half << 8) + (ff << 5) + (tf << 2) + promo;
+        assert(slot >= 4352u && slot < 4864u);
+        return slot;
+    }
+    // EN_PASSANT (type == 2).
+    const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+    const std::uint32_t dir     = std::uint32_t(tf > ff);
+    const std::size_t   slot    = 4864u + ep_half * 16u + tf * 2u + dir;
+    assert(slot >= 4864u && slot < std::size_t(MAINHIST_FREQ_SIZE));
+    return slot;
+}
+
+}  // namespace
+
+std::size_t main_hist_freq_index(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return main_hist_freq_index_special(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t ff   = from & 7u;
+
+    constexpr std::uint64_t PAWN_MASK = 0x00305028140a0c00ULL;
+    const std::uint32_t     same_file = std::uint32_t(((from ^ to) & 7u) == 0u);
+    // (from & 0x38) is fr*8; (to >> 3) is tr; bits don't overlap.
+    const std::uint32_t pawn_pair = std::uint32_t((PAWN_MASK >> ((from & 0x38u) | (to >> 3u))) & 1u);
+    const std::uint32_t     pawn_hit  = same_file & pawn_pair;
+    const std::uint32_t     pawn_mask = std::uint32_t(0u) - pawn_hit;
+
+    const std::uint32_t pawn_color = std::uint32_t(tr < fr);
+    const std::uint32_t is_init    = std::uint32_t((0x42u >> fr) & 1u);
+    const std::uint32_t is_double  = std::uint32_t(((tr ^ fr) & 3u) == 2u);
+    const std::uint32_t idx        = is_init ? is_double : fr;
+    const std::uint32_t pawn_slot  = (pawn_color << 6) | (ff << 3) | idx;
+
+    const std::uint32_t tier2 = 128u + (r & 0xFFFu);
+
+    assert(!pawn_hit || pawn_slot < 128u);
+    assert(tier2 >= 128u && tier2 < 4224u);
+
+    const std::size_t result = std::size_t((pawn_slot & pawn_mask) | (tier2 & ~pawn_mask));
+    assert(result < std::size_t(MAINHIST_FREQ_SIZE));
+    return result;
 }
 
 }  // namespace Stockfish

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>  // IWYU pragma: keep
 #include <cstddef>
+#include <cstdint>
 
 #include "types.h"
 
@@ -36,15 +37,27 @@ enum GenType {
     LEGAL
 };
 
-struct ExtMove: public Move {
-    int value;
+// Sentinel marking an uncomputed freq slot in ExtMove::freq_slot
+// and MovePicker::lastFreqSlot.
+constexpr std::uint16_t NO_FREQ_SLOT = 0xFFFFu;
 
-    void operator=(Move m) { data = m.raw(); }
+// freq_slot caches the freq-aware mainHistory slot from MovePicker::score<>().
+// Reuses the 2-byte slot between Move::data and value that alignment would
+// otherwise leave empty; sizeof(ExtMove) stays at 8 bytes (static_assert below).
+struct ExtMove: public Move {
+    std::uint16_t freq_slot;
+    int           value;
+
+    void operator=(Move m) {
+        data      = m.raw();
+        freq_slot = NO_FREQ_SLOT;
+    }
 
     // Inhibit unwanted implicit conversions to Move
     // with an ambiguity that yields to a compile error.
     operator float() const = delete;
 };
+static_assert(sizeof(ExtMove) == 8, "ExtMove must remain 8 bytes");
 
 inline bool operator<(const ExtMove& f, const ExtMove& s) { return f.value < s.value; }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -157,8 +157,14 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         else if constexpr (Type == QUIETS)
         {
+            // Hoist freq-slot computation early so OOO can interleave it with
+            // the contHist/lowply reads below. Cache slot in ExtMove for reuse
+            // at search-loop sites.
+            const std::size_t freqSlot = main_hist_freq_index(m);
+            m.freq_slot                = std::uint16_t(freqSlot);
+
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][freqSlot];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -184,7 +190,11 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+            {
+                const std::size_t freqSlot = main_hist_freq_index(m);
+                m.freq_slot                = std::uint16_t(freqSlot);
+                m.value = (*mainHistory)[us][freqSlot] + (*continuationHistory[0])[pc][to];
+            }
         }
     }
     return it;
@@ -197,8 +207,12 @@ Move MovePicker::select(Pred filter) {
 
     for (; cur < endCur; ++cur)
         if (*cur != ttMove && filter())
+        {
+            lastFreqSlot = cur->freq_slot;
             return *cur++;
+        }
 
+    lastFreqSlot = NO_FREQ_SLOT;
     return Move::none();
 }
 
@@ -217,6 +231,7 @@ top:
     case QSEARCH_TT :
     case PROBCUT_TT :
         ++stage;
+        lastFreqSlot = std::uint16_t(main_hist_freq_index(ttMove));
         return ttMove;
 
     case CAPTURE_INIT :

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -51,6 +51,10 @@ class MovePicker {
     Move next_move();
     void skip_quiet_moves();
 
+    // freq slot for the most recent move returned by next_move(); used at
+    // search-loop sites to avoid recomputing main_hist_freq_index(move).
+    std::uint16_t lastFreqSlot = NO_FREQ_SLOT;
+
    private:
     template<typename Pred>
     Move select(Pred);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < MAINHIST_FREQ_SIZE; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -593,7 +593,8 @@ void Search::Worker::do_move(
 
     if (ss != nullptr)
     {
-        ss->currentMove = move;
+        ss->currentMove     = move;
+        ss->currentFreqSlot = std::uint16_t(main_hist_freq_index(move));
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -604,6 +605,7 @@ void Search::Worker::do_move(
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
+    ss->currentFreqSlot               = NO_FREQ_SLOT;
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
     ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
 }
@@ -898,7 +900,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1126,7 +1128,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][mp.lastFreqSlot] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1253,7 +1255,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][mp.lastFreqSlot]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1475,7 +1477,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1924,7 +1926,8 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][main_hist_freq_index(move)]
+      << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
         workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;

--- a/src/search.h
+++ b/src/search.h
@@ -102,24 +102,27 @@ struct PVMoves {
 // Stack struct keeps track of the information we need to remember from nodes
 // shallower and deeper in the tree during the search. Each search thread has
 // its own array of Stack objects, indexed by the current ply.
+// Stack: 64-bit-first reordering with 16-bit narrowing of ply, reduction,
+// moveCount, cutoffCnt. Adds 16-bit currentFreqSlot after the other 16-bit
+// fields (fits in what would otherwise be tail padding). Total 48 bytes.
 struct Stack {
     PVMoves*                    pv;
     PieceToHistory*             continuationHistory;
     CorrectionHistory<PieceTo>* continuationCorrectionHistory;
-    int                         ply;
+    int                         statScore;
+    std::int16_t                staticEval;
     Move                        currentMove;
     Move                        excludedMove;
-    Value                       staticEval;
-    int                         statScore;
-    int                         moveCount;
+    std::int16_t                ply;
+    std::int16_t                reduction;
+    std::uint16_t               moveCount;
+    std::uint16_t               cutoffCnt;
+    std::uint16_t               currentFreqSlot;
     bool                        inCheck;
     bool                        ttPv;
     bool                        ttHit;
     bool                        followPV;
-    int                         cutoffCnt;
-    int                         reduction;
 };
-
 
 // RootMove struct is used for moves at the root of the tree. For each root move
 // we store a score and a PV (really a refutation in the case of moves which


### PR DESCRIPTION
## Summary

Lossless freq-aware mainHistory with single-formula pawn slot, layered with
ExtMove::freq_slot and Stack::currentFreqSlot caches over the stack-narrow-48b
Stack layout.

**Bench EQUAL to master at depth 13 (2,723,949) AND depth 20 (59,354,652)** -- the
index function is a true bijection on used moves (lossless permutation).

## Slot layout (4896 slots vs master's 65536)

Identical to no-cache sibling (PR #363):
- `[0, 128)` Pawn slot, `[128, 4224)` NORMAL fallback, `[4224, 4352)` CASTLING,
  `[4352, 4864)` PROMOTION (lossless on `tf`), `[4864, 4896)` EN_PASSANT.

## Cache layer

Three additions over the no-cache sibling:
- `ExtMove::freq_slot` (uint16, zero growth via padding reuse, sizeof stays 8B).
- `Stack::currentFreqSlot` (uint16, fits in stack-narrow-48b's reclaimed space; total Stack = 48 bytes).
- `MovePicker::lastFreqSlot` (uint16, propagated from cur->freq_slot in select).

## Stack layout (48 bytes vs master's 56 bytes)

Stack-narrow-48b layout: ply / reduction / moveCount / cutoffCnt narrowed to
16-bit, staticEval narrowed to int16, currentMove and excludedMove already 16-bit;
new `currentFreqSlot` field placed after the existing 16-bit cluster.
`static_assert(sizeof(Stack) == 48)` passes.

## Bench

- depth 13: **2,723,949 EQUAL master 1a882efc**
- depth 20: **59,354,652 EQUAL master 1a882efc**
- depth 20 NPS: 1,422,281 (vs master 1,460,031; -2.6%)

## Cache instrumentation findings

Empirical counter measurement (cutechess STC 10+0.1, 1 pair, UHO + adjudication, 1T):
- Stack cache write:read ratio 1.83:1 (1.000 do_move writes vs 0.546 ss_freq_reads).
- ExtMove cache write:read ratio 2.57:1 (5.300 score writes vs 2.064 LMR reads).

Both above the ~2:1 break-even where store cost exceeds load savings.
**Sibling no-cache branch (PR #363) is +0.5% NPS faster at depth 20.**

## Bug fixed vs prior `mainhist-freq-aware*` branches

Same lossless-tf fix as PR #363. All four prior branches (`mainhist-freq-aware`,
`mainhist-freq-aware-cached`, `mainhist-fa-no-attr`, `mainhist-fa-noinline`)
collapsed forward-promote and capture-promote at same (from, promo). Fixed by
512-slot promotion encoding.

## Recommendation

Sibling no-cache PR #363 is empirically faster. Recommend testing #363 first.