### PR TITLE
Use unsigned-cast pow-2 division at 16 provably non-negative sites

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -190,7 +190,8 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
-    const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
+    assert(pos.count<ALL_PIECES>() >= 2);
+    const int  bucket = int(unsigned(pos.count<ALL_PIECES>() - 1) >> 2u);
     const auto psqt =
       featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
     const auto positional = network[bucket].propagate(transformedFeatures);
@@ -253,7 +254,8 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
     NnueEvalTrace t{};
-    t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
+    assert(pos.count<ALL_PIECES>() >= 2);
+    t.correctBucket = int(unsigned(pos.count<ALL_PIECES>() - 1) >> 2u);
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
         const auto materialist =

--- a/src/position.h
+++ b/src/position.h
@@ -317,7 +317,10 @@ inline Bitboard Position::check_squares(PieceType pt) const { return st->checkSq
 inline Key Position::key() const { return adjust_key50(st->key); }
 
 inline Key Position::adjust_key50(Key k) const {
-    return st->rule50 < 14 ? k : k ^ make_key((st->rule50 - 14) / 8);
+    int r = st->rule50 - 14;
+    if (r < 0)
+        return k;
+    return k ^ make_key(int(unsigned(r) >> 3u));
 }
 
 inline Key Position::pawn_key() const { return st->pawnKey; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -377,8 +377,9 @@ bool Search::Worker::iterative_deepening() {
             {
                 // Adjust the effective depth searched, but ensure at least one
                 // effective increment for every four searchAgain steps (see issue #2717).
-                Depth adjustedDepth =
-                  std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
+                assert(searchAgainCounter >= 0);
+                Depth adjustedDepth = std::max(
+                  1, rootDepth - failedHighCnt - int(unsigned(3 * (searchAgainCounter + 1)) >> 2u));
                 rootDelta = beta - alpha;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
@@ -916,10 +917,12 @@ Value Search::Worker::search(
     if (!ss->ttPv && depth < 15 && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta)
         && !is_win(eval))
     {
-        Value futilityMult   = 76 - 21 * !ss->ttHit;
-        Value futilityMargin = futilityMult * depth
-                             - (2686 * improving + 362 * opponentWorsening) * futilityMult / 1024
-                             + std::abs(correctionValue) / 180600;
+        Value futilityMult = 76 - 21 * !ss->ttHit;
+        assert(futilityMult >= 0);
+        Value futilityMargin =
+          futilityMult * depth
+          - int(unsigned((2686 * improving + 362 * opponentWorsening) * futilityMult) >> 10u)
+          + std::abs(correctionValue) / 180600;
 
         if (eval - futilityMargin >= beta)
             return (2 * beta + eval) / 3;
@@ -949,7 +952,9 @@ Value Search::Worker::search(
 
             // Do verification search at high depths, with null move pruning disabled
             // until ply exceeds nmpMinPly.
-            nmpMinPly = ss->ply + 3 * (depth - R) / 4;
+            int rd = depth - R;
+            assert(rd >= 0);
+            nmpMinPly = ss->ply + int(unsigned(3 * rd) >> 2u);
 
             Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
 
@@ -1167,8 +1172,9 @@ moves_loop:  // When in check, search starts here
             && is_valid(ttData.value) && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
             && ttData.depth >= depth - 3 && !is_shuffling(move, ss, pos))
         {
-            Value singularBeta  = ttData.value - (60 + 66 * (ss->ttPv && !PvNode)) * depth / 55;
-            Depth singularDepth = newDepth / 2;
+            Value singularBeta = ttData.value - (60 + 66 * (ss->ttPv && !PvNode)) * depth / 55;
+            assert(newDepth >= 0);
+            Depth singularDepth = Depth(unsigned(newDepth) >> 1u);
 
             ss->excludedMove = move;
             value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
@@ -1250,8 +1256,11 @@ moves_loop:  // When in check, search starts here
             r -= 2239;
 
         if (capture)
-            ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
+        {
+            assert(PieceValue[pos.captured_piece()] >= 0);
+            ss->statScore = int(unsigned(863 * int(PieceValue[pos.captured_piece()])) >> 7u)
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
+        }
         else
             ss->statScore = 2 * mainHistory[us][move.raw()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
@@ -1471,14 +1480,16 @@ moves_loop:  // When in check, search starts here
 
         // scaledBonus ranges from 0 to roughly 2.3M, overflows happen for multipliers larger than 900
         const int scaledBonus = std::min(135 * depth - 80, 1400) * bonusScale;
+        assert(scaledBonus >= 0);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      scaledBonus * 221 / 16384);
+                                      int(unsigned(scaledBonus * 221) >> 14u));
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][((ss - 1)->currentMove).raw()] << int(unsigned(scaledBonus * 235) >> 15u);
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq]
+              << int(unsigned(scaledBonus * 290) >> 13u);
     }
 
     // Bonus for prior capture countermove that caused the fail low
@@ -1766,7 +1777,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
 int Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
     int reductionScale = reductions[d] * reductions[mn];
-    return reductionScale - delta * 585 / rootDelta + !i * reductionScale * 206 / 512 + 1133;
+    assert(reductionScale >= 0);
+    return reductionScale - delta * 585 / rootDelta + int(unsigned(!i * reductionScale * 206) >> 9u)
+         + 1133;
 }
 
 // elapsed() returns the time elapsed since the search started. If the
@@ -1855,16 +1868,18 @@ void update_all_stats(const Position& pos,
     int bonus =
       std::min(128 * depth - 77, 1529) + 353 * (bestMove == ttMove) + (ss - 1)->statScore / 32;
     int malus = std::min(882 * depth - 204, 2122);
+    assert(malus >= 0);
 
     if (!pos.capture_stage(bestMove))
     {
         update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 806 / 1024);
 
-        int actualMalus = malus * 1113 / 1024;
+        int actualMalus = int(unsigned(malus * 1113) >> 10u);
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
         {
-            actualMalus = actualMalus * 977 / 1024;
+            assert(actualMalus >= 0);
+            actualMalus = int(unsigned(actualMalus * 977) >> 10u);
             update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
         }
     }
@@ -1878,14 +1893,16 @@ void update_all_stats(const Position& pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 616 / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
+                                      -int(unsigned(malus * 616) >> 10u));
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
         movedPiece    = pos.moved_piece(move);
         capturedPiece = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -malus * 1559 / 1024;
+        captureHistory[movedPiece][move.to_sq()][capturedPiece]
+          << -int(unsigned(malus * 1559) >> 10u);
     }
 }
 


### PR DESCRIPTION
Replaces 16 power-of-two integer divisions in master with the
`assert + int(unsigned(x) >> Nu)` pattern at sites where the dividend
is provably non-negative at the program point. All other power-of-two
`/` sites in master are kept verbatim.

Bench: 2723949 (byte-equal master 1a882efc).

This is a strict subset of an earlier broader idiv-shift exploration
that selected only the byte-equal-master sites. The substitution
converts trunc-div to right-shift; for non-negative signed dividends
both operations yield the same result, so the search tree is
unchanged. Asserts document the positivity proof at each site and
catch a future code change that invalidates it in debug builds.

Whole-binary idiv count: 155 -> 136 (-19). Cumulative -62 instructions
across search<NonPV>, search<PV>, and update_all_stats. GCC and
Clang lower signed `/N` for compile-time pow-2 N to a 4-insn sequence
(lea/test/cmovns/sar) rather than to idiv; the unsigned cast
collapses each such occurrence to a single `shr`.

Sites converted (16 total):

- nnue/network.cpp:193, 256: `(pos.count<ALL_PIECES>() - 1) / 4`. count >= 2 always.
- position.h:320: `(st->rule50 - 14) / 8` in adjust_key50, gated by `if (st->rule50 < 14) return k;`.
- search.cpp:381: adjustedDepth `3 * (searchAgainCounter + 1) / 4`. searchAgainCounter int >= 0.
- search.cpp:921: futilityMargin `(2686*imp + 362*opp) * futilityMult / 1024`. futilityMult in {55, 76}.
- search.cpp:952: nmpMinPly `3 * (depth - R) / 4`.
- search.cpp:1171: singularDepth `newDepth / 2`.
- search.cpp:1253: capture statScore `863 * int(PieceValue[captured]) / 128`. PieceValue table is all VALUE_ZERO or positive.
- search.cpp:1476, 1478, 1481: scaledBonus history writes. depth >= 1 inside search<> and bonusScale = max(..., 0).
- search.cpp:1769: Worker::reduction `!i * reductionScale * 206 / 512`. reductionScale = reductions[d]*reductions[mn], both >= 0.
- search.cpp:1863, 1867, 1881, 1888: malus / actualMalus shifts in update_all_stats. malus = min(882*depth - 204, 2122) >= 678 inside search<>.

Sites kept as master `/` are those with signed dividends at runtime
(history accumulators, bonus that can be negative, eval differences,
statScore, r reduction, qsearch averaging) or on cold paths
(FEN print, version string, TB probe, UCI mate output).

The `int(unsigned(x) >> Nu)` form sidesteps the C++17 implementation-
defined behavior for signed `>>` on negative values, since the shift
is always on an unsigned operand and the back-cast `int(unsigned y)`
is well-defined when `y <= INT_MAX` (the positivity proof guarantees
this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized core evaluation and search algorithm computations for improved engine efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->