### PR TITLE
Freq-aware mainHistory and lowPlyHistory via 32 KiB v8 LUT, inlined

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,15 +128,32 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// history_slot maps a Move to a slot index in [0, HISTORY_SLOT_COUNT).
+// The mapping is structural: pawn pushes / chebyshev=1 / knight L /
+// 2-step ray / flat fallback / promotion / castling / en passant.
+// All inputs map to a valid slot; corrupt or aliased TT moves cannot
+// escape the table bounds.
+constexpr int HISTORY_SLOT_COUNT = 5952;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+extern const std::array<std::uint16_t, 0x4000> FREQ_SLOT_V8_NORMAL;
+
+sf_noinline std::size_t special_slot(std::uint32_t r);
+
+inline sf_always_inline std::size_t history_slot(Move m) {
+    const std::uint32_t r = std::uint32_t(m.raw());
+    if (r >= 0x4000u)
+        return special_slot(r);
+    return FREQ_SLOT_V8_NORMAL[r];
+}
+
+// ButterflyHistory: per-color quiet-move success counters, indexed by
+// [color][history_slot(move)]. Used for move ordering and reductions.
+// See https://www.chessprogramming.org/Butterfly_Boards.
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, HISTORY_SLOT_COUNT>;
+
+// LowPlyHistory: per-ply quiet-move success counters near the root, indexed
+// by [ply][history_slot(move)]. Same slot space as ButterflyHistory.
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, HISTORY_SLOT_COUNT>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/misc.h
+++ b/src/misc.h
@@ -509,11 +509,14 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
+    #define sf_noinline __attribute__((noinline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
+    #define sf_noinline __declspec(noinline)
 #else
     // do nothing for other compilers
     #define sf_always_inline
+    #define sf_noinline
 #endif
 
 #if defined(__clang__)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -18,14 +18,17 @@
 
 #include "movegen.h"
 
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
-    #include <array>
     #include <algorithm>
     #include <immintrin.h>
 #endif
@@ -366,5 +369,127 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
 
     return moveList;
 }
+
+namespace {
+
+// Tier boundaries; layout documented in history.h.
+constexpr std::uint32_t TIER_PAWN_INIT = 0u;
+constexpr std::uint32_t TIER_PAWN_CONT = 32u;
+constexpr std::uint32_t TIER_CHEBYSHEV = 96u;
+constexpr std::uint32_t TIER_KNIGHT    = 608u;
+constexpr std::uint32_t TIER_RAY2      = 1120u;
+constexpr std::uint32_t TIER_FALLBACK  = 1632u;
+constexpr std::uint32_t TIER_PROMOTION = 5728u;
+constexpr std::uint32_t TIER_CASTLING  = 5792u;
+constexpr std::uint32_t TIER_EN_PASS   = 5920u;
+
+static_assert(TIER_EN_PASS + 32u == HISTORY_SLOT_COUNT,
+              "slot layout / HISTORY_SLOT_COUNT mismatch");
+
+constexpr std::size_t compute_special_slot(std::uint32_t r) {
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t half = from >> 5;
+
+    if (type == 1u)
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        return TIER_PROMOTION + (half << 5) + ff * 4u + promo;
+    }
+    if (type == 3u)
+    {
+        return TIER_CASTLING + half * 64u + ff * 8u + tf;
+    }
+    // type == 2u (en passant) or corrupt TT input that survived release-mode
+    // pseudo_legal checks; rare but handled to a valid slot.
+    const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+    const std::uint32_t dir     = std::uint32_t(tf > ff);
+    return TIER_EN_PASS + ep_half * 16u + tf * 2u + dir;
+}
+
+constexpr std::size_t compute_freq_aware_slot(std::uint32_t r) {
+    if (r >= 0x4000u)
+        return compute_special_slot(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+
+    if (ff == tf)
+    {
+        if (fr == 1u && (tr == 2u || tr == 3u))
+            return TIER_PAWN_INIT + ff * 2u + (tr - 2u);
+        if (fr == 6u && (tr == 5u || tr == 4u))
+            return TIER_PAWN_INIT + 16u + ff * 2u + (5u - tr);
+        if (fr >= 2u && fr <= 5u && tr == fr + 1u)
+            return TIER_PAWN_CONT + ff * 4u + (fr - 2u);
+        if (fr >= 2u && fr <= 5u && tr + 1u == fr)
+            return TIER_PAWN_CONT + 32u + ff * 4u + (fr - 2u);
+    }
+
+    const int fdiff = int(tf) - int(ff);
+    const int rdiff = int(tr) - int(fr);
+    if (fdiff >= -1 && fdiff <= 1 && rdiff >= -1 && rdiff <= 1 && (fdiff != 0 || rdiff != 0))
+    {
+        const std::uint32_t pos  = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+        const std::uint32_t dest = pos < 4u ? pos : pos - 1u;
+        return TIER_CHEBYSHEV + fr * 64u + ff * 8u + dest;
+    }
+
+    const int absfd = fdiff < 0 ? -fdiff : fdiff;
+    const int absrd = rdiff < 0 ? -rdiff : rdiff;
+
+    // Knight L-move
+    if (absfd * absfd + absrd * absrd == 5)
+    {
+        const std::uint32_t kidx = (std::uint32_t(fdiff > 0) << 2)
+                                 | (std::uint32_t(absfd == 1) << 1) | std::uint32_t(rdiff > 0);
+        return TIER_KNIGHT + from * 8u + kidx;
+    }
+
+    // 2-step ray (orth distance 2 or diag distance 2)
+    if ((absfd == 2 && absrd == 0) || (absfd == 0 && absrd == 2))
+    {
+        const std::uint32_t ridx = (absfd == 0) ? (rdiff > 0 ? 0u : 2u) : (fdiff > 0 ? 1u : 3u);
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+    if (absfd == 2 && absrd == 2)
+    {
+        const std::uint32_t ridx =
+          4u + ((std::uint32_t(fdiff > 0) << 1) | std::uint32_t(rdiff < 0));
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+
+    return TIER_FALLBACK + ((from << 6) | to);
+}
+
+constexpr std::array<std::uint16_t, 0x4000> build_normal_slot_table() {
+    std::array<std::uint16_t, 0x4000> t{};
+    for (std::uint32_t r = 0; r < 0x4000u; ++r)
+        t[r] = static_cast<std::uint16_t>(compute_freq_aware_slot(r));
+    return t;
+}
+
+constexpr bool all_slots_in_range() {
+    for (std::uint32_t r = 0; r < 65536u; ++r)
+        if (compute_freq_aware_slot(r) >= std::size_t(HISTORY_SLOT_COUNT))
+            return false;
+    return true;
+}
+
+static_assert(all_slots_in_range(), "history_slot result exceeds HISTORY_SLOT_COUNT");
+
+}  // namespace
+
+extern const std::array<std::uint16_t, 0x4000> FREQ_SLOT_V8_NORMAL = build_normal_slot_table();
+
+sf_noinline std::size_t special_slot(std::uint32_t r) { return compute_special_slot(r); }
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -228,7 +228,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         else if constexpr (Type == QUIETS)
         {
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][history_slot(m)];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -246,7 +246,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][history_slot(m)] / (1 + ply);
         }
 
         else  // Type == EVASIONS
@@ -254,7 +254,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value = (*mainHistory)[us][history_slot(m)] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < HISTORY_SLOT_COUNT; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -897,7 +897,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][history_slot((ss - 1)->currentMove)] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1127,7 +1127,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][history_slot(move)] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1254,7 +1254,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][history_slot(move)]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1476,7 +1476,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][history_slot((ss - 1)->currentMove)] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1925,10 +1925,11 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][history_slot(move)]
+      << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][history_slot(move)] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Variant of mainhist-fa-v8-lut that splits history_slot into an sf_always_inline hot path and an sf_noinline cold helper (special_slot), mirroring mainhist-fa-oracle-attr. Hot path reads from a 32 KiB LUT (16384 entries) keyed on raw<0x4000 (NORMAL moves); promotion/castling/en-passant/corrupt-TT inputs go through the out-of-line helper. Slot layout (5952 slots, v8 mapping) unchanged.

Bench: 2344696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal move history indexing system with an optimized slot-based mapping mechanism to improve move evaluation efficiency across the engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->