### PR TITLE
Freq-aware mainHistory v8 with shared LUT and Stack-only cache

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,15 +128,31 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// history_slot maps a Move to a slot index in [0, HISTORY_SLOT_COUNT) and is
+// a bijection over the realized Move::raw() values encountered in search.
+// The mapping packs frequently used moves into low slot indices using
+// chess priors, giving a denser layout than the raw 16-bit Move encoding.
+//
+// Slot layout (shared by ButterflyHistory and LowPlyHistory):
+//   [0,    96)   pawn pushes (initial-rank, then continuation single-pushes)
+//   [96,  608)   chebyshev=1 from any rank (king-like one-step)
+//   [608, 1120)  knight L-moves (64 from-squares x 8 directions)
+//   [1120, 1632) two-step ray moves (orth or diag, distance exactly 2)
+//   [1632, 5728) fallback for other NORMAL moves: (from << 6) | to
+//   [5728, 5952) promotion / castling / en passant
+//   [5952, 5954) sentinels for Move::none and Move::null
+constexpr int HISTORY_SLOT_COUNT = 5954;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+std::size_t history_slot(Move m);
+
+// ButterflyHistory: per-color quiet-move success counters, indexed by
+// [color][history_slot(move)]. Used for move ordering and reductions.
+// See https://www.chessprogramming.org/Butterfly_Boards.
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, HISTORY_SLOT_COUNT>;
+
+// LowPlyHistory: per-ply quiet-move success counters near the root, indexed
+// by [ply][history_slot(move)]. Same slot space as ButterflyHistory.
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, HISTORY_SLOT_COUNT>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -18,14 +18,17 @@
 
 #include "movegen.h"
 
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
-    #include <array>
     #include <algorithm>
     #include <immintrin.h>
 #endif
@@ -366,5 +369,139 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
 
     return moveList;
 }
+
+namespace {
+
+// Tier boundaries for the slot layout in history.h.
+constexpr std::uint32_t TIER_PAWN_INIT = 0u;
+constexpr std::uint32_t TIER_PAWN_CONT = 32u;
+constexpr std::uint32_t TIER_CHEBYSHEV = 96u;
+constexpr std::uint32_t TIER_KNIGHT    = 608u;
+constexpr std::uint32_t TIER_RAY2      = 1120u;
+constexpr std::uint32_t TIER_FALLBACK  = 1632u;
+constexpr std::uint32_t TIER_PROMOTION = 5728u;
+constexpr std::uint32_t TIER_CASTLING  = 5792u;
+constexpr std::uint32_t TIER_EN_PASS   = 5920u;
+constexpr std::uint32_t SLOT_NONE      = 5952u;
+constexpr std::uint32_t SLOT_NULL      = 5953u;
+
+static_assert(SLOT_NULL + 1 == HISTORY_SLOT_COUNT, "slot layout / HISTORY_SLOT_COUNT mismatch");
+
+constexpr std::size_t compute_special_slot(std::uint32_t r) {
+    if (r == 0u)
+        return SLOT_NONE;
+    if (r == 65u)
+        return SLOT_NULL;
+
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t half = from >> 5;
+
+    if (type == 1u)
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        return TIER_PROMOTION + (half << 5) + ff * 4u + promo;
+    }
+    if (type == 3u)
+    {
+        return TIER_CASTLING + half * 64u + ff * 8u + tf;
+    }
+    if (type == 2u)
+    {
+        const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+        const std::uint32_t dir     = std::uint32_t(tf > ff);
+        return TIER_EN_PASS + ep_half * 16u + tf * 2u + dir;
+    }
+    assert(false && "compute_special_slot called with NORMAL move type");
+    return SLOT_NONE;
+}
+
+constexpr std::size_t compute_freq_aware_slot(std::uint32_t r) {
+    if (r == 0u || r == 65u || (r >> 14) != 0u)
+        return compute_special_slot(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+
+    if (ff == tf)
+    {
+        if (fr == 1u && (tr == 2u || tr == 3u))
+            return TIER_PAWN_INIT + ff * 2u + (tr - 2u);
+        if (fr == 6u && (tr == 5u || tr == 4u))
+            return TIER_PAWN_INIT + 16u + ff * 2u + (5u - tr);
+        if (fr >= 2u && fr <= 5u && tr == fr + 1u)
+            return TIER_PAWN_CONT + ff * 4u + (fr - 2u);
+        if (fr >= 2u && fr <= 5u && tr + 1u == fr)
+            return TIER_PAWN_CONT + 32u + ff * 4u + (fr - 2u);
+    }
+
+    const int fdiff = int(tf) - int(ff);
+    const int rdiff = int(tr) - int(fr);
+    if (fdiff >= -1 && fdiff <= 1 && rdiff >= -1 && rdiff <= 1 && (fdiff != 0 || rdiff != 0))
+    {
+        const std::uint32_t pos  = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+        const std::uint32_t dest = pos < 4u ? pos : pos - 1u;
+        return TIER_CHEBYSHEV + fr * 64u + ff * 8u + dest;
+    }
+
+    const int absfd = fdiff < 0 ? -fdiff : fdiff;
+    const int absrd = rdiff < 0 ? -rdiff : rdiff;
+
+    // Knight L-move.
+    if (absfd * absfd + absrd * absrd == 5)
+    {
+        const std::uint32_t kidx = (std::uint32_t(fdiff > 0) << 2)
+                                 | (std::uint32_t(absfd == 1) << 1) | std::uint32_t(rdiff > 0);
+        return TIER_KNIGHT + from * 8u + kidx;
+    }
+
+    // Two-step ray (orth or diag, distance exactly 2).
+    const bool orth2 = (absfd == 2 && absrd == 0) || (absfd == 0 && absrd == 2);
+    const bool diag2 = (absfd == 2 && absrd == 2);
+    if (orth2)
+    {
+        const std::uint32_t ridx =
+          (absfd == 0) ? (rdiff > 0 ? 0u : 2u) : (fdiff > 0 ? 1u : 3u);
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+    if (diag2)
+    {
+        const std::uint32_t ridx =
+          4u + ((std::uint32_t(fdiff > 0) << 1) | std::uint32_t(rdiff < 0));
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+
+    return TIER_FALLBACK + ((from << 6) | to);
+}
+
+constexpr std::array<std::uint16_t, 65536> build_freq_slot_table() {
+    std::array<std::uint16_t, 65536> t{};
+    for (std::uint32_t r = 0; r < 65536; ++r)
+        t[r] = static_cast<std::uint16_t>(compute_freq_aware_slot(r));
+    return t;
+}
+
+constexpr bool all_slots_in_range() {
+    for (std::uint32_t r = 0; r < 65536; ++r)
+        if (compute_freq_aware_slot(r) >= std::size_t(HISTORY_SLOT_COUNT))
+            return false;
+    return true;
+}
+
+static_assert(all_slots_in_range(), "history_slot result exceeds HISTORY_SLOT_COUNT");
+
+constexpr std::array<std::uint16_t, 65536> freq_slot_table = build_freq_slot_table();
+
+}  // namespace
+
+std::size_t history_slot(Move m) { return freq_slot_table[std::uint32_t(m.raw())]; }
 
 }  // namespace Stockfish

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>  // IWYU pragma: keep
 #include <cstddef>
+#include <cstdint>
 
 #include "types.h"
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -227,8 +227,9 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         else if constexpr (Type == QUIETS)
         {
+            const std::size_t slot = history_slot(m);
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][slot];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -246,7 +247,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][slot] / (1 + ply);
         }
 
         else  // Type == EVASIONS
@@ -254,7 +255,10 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+            {
+                const std::size_t slot = history_slot(m);
+                m.value = (*mainHistory)[us][slot] + (*continuationHistory[0])[pc][to];
+            }
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < HISTORY_SLOT_COUNT; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -592,7 +592,8 @@ void Search::Worker::do_move(
 
     if (ss != nullptr)
     {
-        ss->currentMove = move;
+        ss->currentMove     = move;
+        ss->currentFreqSlot = std::uint16_t(history_slot(move));
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -603,6 +604,7 @@ void Search::Worker::do_move(
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
     ss->currentMove                   = Move::null();
+    ss->currentFreqSlot               = 0;
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
     ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
 }
@@ -897,7 +899,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1127,7 +1129,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][history_slot(move)] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1254,7 +1256,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][history_slot(move)]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1476,7 +1478,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1924,11 +1926,12 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
-    Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    Color             us   = pos.side_to_move();
+    const std::size_t slot = history_slot(move);
+    workerThread.mainHistory[us][slot] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][slot] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 

--- a/src/search.h
+++ b/src/search.h
@@ -118,6 +118,7 @@ struct Stack {
     bool                        followPV;
     int                         cutoffCnt;
     int                         reduction;
+    std::uint16_t               currentFreqSlot;
 };
 
 


### PR DESCRIPTION
## Summary

Replaces the master mainHistory and lowPlyHistory raw-Move indexing with a frequency-aware permutation through a 128 KiB LUT. The new layout packs frequently used moves (pawn pushes, chebyshev=1 / king-like moves, knight L-moves, two-step rays) into low slot indices. Total slot count is 5954 vs the master 65536, shrinking the stored history table footprint while keeping the lookup a single load.

Stack cache only: ExtMove::freq_slot is NOT used. The 16-bit `currentFreqSlot` is kept on the search Stack and written by do_move; consumer sites at search.cpp:902, 1132, 1259, 1481 either read the cached value or recompute via `history_slot(move)`. Avoiding the ExtMove field eliminates the AVX-512 MoveSorter packing dependency that was a bug source in the cached variants.

Bijection over realized Move::raw() values, so master bench is preserved at depths 13/20/21.

## Bench

2344696

## Local NPS measurement

Pyshbench 100 runs on Sapphire Rapids, GCC PGO build, avx512icl:

```
base (master)             = 607,428 +/- 989 nps
test (mainhist-fa-l128k-stack) = 605,275 +/- 978 nps
diff                      = -2,153 +/- 424
speedup                   = -0.35%   P(speedup>0) = 0.0000
```

NPS regression is small. The freq-aware permutation is a directional bet that hot quiet history accesses (which dominate cache reuse) gain from being clustered in low slot indices, with the speed cost recovered at SMP / longer time controls via cache-line reuse.

## Test plan

- [x] Bench byte-equal master at depths 13, 20, 21
- [x] Pyshbench 100 runs on avx512icl
- [ ] Fishtest STC SMP (in progress)
- [ ] Fishtest LTC SMP (gated on STC SMP outcome)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the move history indexing system used during search. Updated move evaluation and scoring logic to use an optimized slot-based approach for more efficient move ordering and selection in the search algorithm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->