### PR TITLE
Freq-aware mainHistory v8 with shared LUT, ExtMove+Stack cache, hoisted slot pre-write

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,15 +128,31 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-// ButterflyHistory records how often quiet moves have been successful or unsuccessful
-// during the current search, and is used for reduction and move ordering decisions.
-// It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+// history_slot maps a Move to a slot index in [0, HISTORY_SLOT_COUNT) and is
+// a bijection over the realized Move::raw() values encountered in search.
+// The mapping packs frequently used moves into low slot indices using
+// chess priors, giving a denser layout than the raw 16-bit Move encoding.
+//
+// Slot layout (shared by ButterflyHistory and LowPlyHistory):
+//   [0,    96)   pawn pushes (initial-rank, then continuation single-pushes)
+//   [96,  608)   chebyshev=1 from any rank (king-like one-step)
+//   [608, 1120)  knight L-moves (64 from-squares x 8 directions)
+//   [1120, 1632) two-step ray moves (orth or diag, distance exactly 2)
+//   [1632, 5728) fallback for other NORMAL moves: (from << 6) | to
+//   [5728, 5952) promotion / castling / en passant
+//   [5952, 5954) sentinels for Move::none and Move::null
+constexpr int HISTORY_SLOT_COUNT = 5954;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+std::size_t history_slot(Move m);
+
+// ButterflyHistory: per-color quiet-move success counters, indexed by
+// [color][history_slot(move)]. Used for move ordering and reductions.
+// See https://www.chessprogramming.org/Butterfly_Boards.
+using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, HISTORY_SLOT_COUNT>;
+
+// LowPlyHistory: per-ply quiet-move success counters near the root, indexed
+// by [ply][history_slot(move)]. Same slot space as ButterflyHistory.
+using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, HISTORY_SLOT_COUNT>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -18,14 +18,17 @@
 
 #include "movegen.h"
 
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 
 #include "bitboard.h"
+#include "history.h"
 #include "position.h"
 
 #if defined(USE_AVX512ICL)
-    #include <array>
     #include <algorithm>
     #include <immintrin.h>
 #endif
@@ -366,5 +369,139 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
 
     return moveList;
 }
+
+namespace {
+
+// Tier boundaries for the slot layout in history.h.
+constexpr std::uint32_t TIER_PAWN_INIT = 0u;
+constexpr std::uint32_t TIER_PAWN_CONT = 32u;
+constexpr std::uint32_t TIER_CHEBYSHEV = 96u;
+constexpr std::uint32_t TIER_KNIGHT    = 608u;
+constexpr std::uint32_t TIER_RAY2      = 1120u;
+constexpr std::uint32_t TIER_FALLBACK  = 1632u;
+constexpr std::uint32_t TIER_PROMOTION = 5728u;
+constexpr std::uint32_t TIER_CASTLING  = 5792u;
+constexpr std::uint32_t TIER_EN_PASS   = 5920u;
+constexpr std::uint32_t SLOT_NONE      = 5952u;
+constexpr std::uint32_t SLOT_NULL      = 5953u;
+
+static_assert(SLOT_NULL + 1 == HISTORY_SLOT_COUNT, "slot layout / HISTORY_SLOT_COUNT mismatch");
+
+constexpr std::size_t compute_special_slot(std::uint32_t r) {
+    if (r == 0u)
+        return SLOT_NONE;
+    if (r == 65u)
+        return SLOT_NULL;
+
+    const std::uint32_t type = (r >> 14) & 3u;
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t half = from >> 5;
+
+    if (type == 1u)
+    {
+        const std::uint32_t promo = (r >> 12) & 3u;
+        return TIER_PROMOTION + (half << 5) + ff * 4u + promo;
+    }
+    if (type == 3u)
+    {
+        return TIER_CASTLING + half * 64u + ff * 8u + tf;
+    }
+    if (type == 2u)
+    {
+        const std::uint32_t ep_half = std::uint32_t(fr >= 4u);
+        const std::uint32_t dir     = std::uint32_t(tf > ff);
+        return TIER_EN_PASS + ep_half * 16u + tf * 2u + dir;
+    }
+    assert(false && "compute_special_slot called with NORMAL move type");
+    return SLOT_NONE;
+}
+
+constexpr std::size_t compute_freq_aware_slot(std::uint32_t r) {
+    if (r == 0u || r == 65u || (r >> 14) != 0u)
+        return compute_special_slot(r);
+
+    const std::uint32_t from = (r >> 6) & 0x3Fu;
+    const std::uint32_t to   = r & 0x3Fu;
+    const std::uint32_t fr   = from >> 3;
+    const std::uint32_t tr   = to >> 3;
+    const std::uint32_t ff   = from & 7u;
+    const std::uint32_t tf   = to & 7u;
+
+    if (ff == tf)
+    {
+        if (fr == 1u && (tr == 2u || tr == 3u))
+            return TIER_PAWN_INIT + ff * 2u + (tr - 2u);
+        if (fr == 6u && (tr == 5u || tr == 4u))
+            return TIER_PAWN_INIT + 16u + ff * 2u + (5u - tr);
+        if (fr >= 2u && fr <= 5u && tr == fr + 1u)
+            return TIER_PAWN_CONT + ff * 4u + (fr - 2u);
+        if (fr >= 2u && fr <= 5u && tr + 1u == fr)
+            return TIER_PAWN_CONT + 32u + ff * 4u + (fr - 2u);
+    }
+
+    const int fdiff = int(tf) - int(ff);
+    const int rdiff = int(tr) - int(fr);
+    if (fdiff >= -1 && fdiff <= 1 && rdiff >= -1 && rdiff <= 1 && (fdiff != 0 || rdiff != 0))
+    {
+        const std::uint32_t pos  = std::uint32_t(fdiff + 1) * 3u + std::uint32_t(rdiff + 1);
+        const std::uint32_t dest = pos < 4u ? pos : pos - 1u;
+        return TIER_CHEBYSHEV + fr * 64u + ff * 8u + dest;
+    }
+
+    const int absfd = fdiff < 0 ? -fdiff : fdiff;
+    const int absrd = rdiff < 0 ? -rdiff : rdiff;
+
+    // Knight L-move.
+    if (absfd * absfd + absrd * absrd == 5)
+    {
+        const std::uint32_t kidx = (std::uint32_t(fdiff > 0) << 2)
+                                 | (std::uint32_t(absfd == 1) << 1) | std::uint32_t(rdiff > 0);
+        return TIER_KNIGHT + from * 8u + kidx;
+    }
+
+    // Two-step ray (orth or diag, distance exactly 2).
+    const bool orth2 = (absfd == 2 && absrd == 0) || (absfd == 0 && absrd == 2);
+    const bool diag2 = (absfd == 2 && absrd == 2);
+    if (orth2)
+    {
+        const std::uint32_t ridx =
+          (absfd == 0) ? (rdiff > 0 ? 0u : 2u) : (fdiff > 0 ? 1u : 3u);
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+    if (diag2)
+    {
+        const std::uint32_t ridx =
+          4u + ((std::uint32_t(fdiff > 0) << 1) | std::uint32_t(rdiff < 0));
+        return TIER_RAY2 + from * 8u + ridx;
+    }
+
+    return TIER_FALLBACK + ((from << 6) | to);
+}
+
+constexpr std::array<std::uint16_t, 65536> build_freq_slot_table() {
+    std::array<std::uint16_t, 65536> t{};
+    for (std::uint32_t r = 0; r < 65536; ++r)
+        t[r] = static_cast<std::uint16_t>(compute_freq_aware_slot(r));
+    return t;
+}
+
+constexpr bool all_slots_in_range() {
+    for (std::uint32_t r = 0; r < 65536; ++r)
+        if (compute_freq_aware_slot(r) >= std::size_t(HISTORY_SLOT_COUNT))
+            return false;
+    return true;
+}
+
+static_assert(all_slots_in_range(), "history_slot result exceeds HISTORY_SLOT_COUNT");
+
+constexpr std::array<std::uint16_t, 65536> freq_slot_table = build_freq_slot_table();
+
+}  // namespace
+
+std::size_t history_slot(Move m) { return freq_slot_table[std::uint32_t(m.raw())]; }
 
 }  // namespace Stockfish

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>  // IWYU pragma: keep
 #include <cstddef>
+#include <cstdint>
 
 #include "types.h"
 
@@ -36,15 +37,32 @@ enum GenType {
     LEGAL
 };
 
-struct ExtMove: public Move {
-    int value;
+// Sentinel for the freq-aware slot caches. Debug-only: in release the
+// caches are populated lazily by score<>() / select() / TT-case writes
+// for all moves whose mainHistory consumer might fire (real captures
+// pay the LUT load only because promotion-to-queen non-captures go
+// through CAPTURES phase but are gated by !priorCapture, requiring a
+// valid slot). In debug, the sentinel poisons unscored entries.
+#if !defined(NDEBUG)
+constexpr std::uint16_t NO_FREQ_SLOT = 0xFFFFu;
+#endif
 
-    void operator=(Move m) { data = m.raw(); }
+struct ExtMove: public Move {
+    std::uint16_t freq_slot;
+    int           value;
+
+    void operator=(Move m) {
+        data = m.raw();
+#if !defined(NDEBUG)
+        freq_slot = NO_FREQ_SLOT;
+#endif
+    }
 
     // Inhibit unwanted implicit conversions to Move
     // with an ambiguity that yields to a compile error.
     operator float() const = delete;
 };
+static_assert(sizeof(ExtMove) == 8, "ExtMove must remain 8 bytes");
 
 inline bool operator<(const ExtMove& f, const ExtMove& s) { return f.value < s.value; }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,6 +19,7 @@
 #include "movepick.h"
 
 #include <cassert>
+#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -57,9 +58,14 @@ enum Stages {
 };
 
 #ifdef USE_AVX512ICL
-// Load the Move, and the ExtMove value, into all lanes of 512-bit registers
+// Load the Move + freq_slot pair, and the ExtMove value, into all lanes of
+// 512-bit registers. The low 32 bits of ExtMove pack data (raw Move) and
+// freq_slot; both must travel through the sorter together so write_sorted
+// stores them back atomically and freq_slot is preserved.
 static void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
-    move  = _mm512_set1_epi32(m.raw());
+    std::uint32_t packed;
+    std::memcpy(&packed, &m, sizeof(packed));
+    move  = _mm512_set1_epi32(int(packed));
     value = _mm512_set1_epi32(m.value);
 }
 
@@ -222,13 +228,21 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         const Piece     capturedPiece = pos.piece_on(to);
 
         if constexpr (Type == CAPTURES)
-            m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
+        {
+            // Promotion-to-queen non-captures route through CAPTURES because
+            // capture_stage() treats them as captures for sorting; their
+            // priorCapture-gated mainHistory consumers need a valid slot.
+            m.freq_slot = std::uint16_t(history_slot(m));
+            m.value     = (*captureHistory)[pc][to][type_of(capturedPiece)]
                     + 7 * int(PieceValue[capturedPiece]);
+        }
 
         else if constexpr (Type == QUIETS)
         {
+            const std::size_t slot = history_slot(m);
+            m.freq_slot            = std::uint16_t(slot);
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][slot];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -246,15 +260,17 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][slot] / (1 + ply);
         }
 
         else  // Type == EVASIONS
         {
+            const std::size_t slot = history_slot(m);
+            m.freq_slot            = std::uint16_t(slot);
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value = (*mainHistory)[us][slot] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;
@@ -267,8 +283,14 @@ Move MovePicker::select(Pred filter) {
 
     for (; cur < endCur; ++cur)
         if (*cur != ttMove && filter())
+        {
+            lastFreqSlot = cur->freq_slot;
             return *cur++;
+        }
 
+#if !defined(NDEBUG)
+    lastFreqSlot = NO_FREQ_SLOT;
+#endif
     return Move::none();
 }
 
@@ -287,6 +309,7 @@ top:
     case QSEARCH_TT :
     case PROBCUT_TT :
         ++stage;
+        lastFreqSlot = std::uint16_t(history_slot(ttMove));
         return ttMove;
 
     case CAPTURE_INIT :

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -51,6 +51,16 @@ class MovePicker {
     Move next_move();
     void skip_quiet_moves();
 
+    // Cached freq slot for the most recent move returned by next_move(),
+    // used at search-loop sites to avoid recomputing history_slot(move).
+    // Initial value irrelevant in release: every consumer read is gated
+    // by a path that has overwritten the cache for the current move.
+    std::uint16_t lastFreqSlot
+#if !defined(NDEBUG)
+      = NO_FREQ_SLOT
+#endif
+      ;
+
    private:
     template<typename Pred>
     Move select(Pred);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,7 +318,7 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+        for (int i = 0; i < HISTORY_SLOT_COUNT; i++)
             mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
@@ -602,7 +602,10 @@ void Search::Worker::do_move(
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
     pos.do_null_move(st);
-    ss->currentMove                   = Move::null();
+    ss->currentMove = Move::null();
+#if !defined(NDEBUG)
+    ss->currentFreqSlot = NO_FREQ_SLOT;
+#endif
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
     ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
 }
@@ -897,7 +900,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -993,6 +996,7 @@ Value Search::Worker::search(
 
             assert(pos.capture_stage(move));
 
+            ss->currentFreqSlot = mp.lastFreqSlot;
             do_move(pos, move, st, ss);
 
             // Perform a preliminary qsearch to verify that the move holds
@@ -1127,7 +1131,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][mp.lastFreqSlot] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1219,6 +1223,7 @@ moves_loop:  // When in check, search starts here
         }
 
         // Step 16. Make the move
+        ss->currentFreqSlot = mp.lastFreqSlot;
         do_move(pos, move, st, givesCheck, ss);
 
         // Add extension to new depth
@@ -1254,7 +1259,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
+            ss->statScore = 2 * mainHistory[us][mp.lastFreqSlot]
                           + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
@@ -1476,7 +1481,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][(ss - 1)->currentFreqSlot] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1705,6 +1710,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         }
 
         // Step 7. Make and search the move
+        ss->currentFreqSlot = mp.lastFreqSlot;
         do_move(pos, move, st, givesCheck, ss);
 
         value = -qsearch<nodeType>(pos, ss + 1, -beta, -alpha);
@@ -1924,11 +1930,12 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
-    Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    Color             us   = pos.side_to_move();
+    const std::size_t slot = history_slot(move);
+    workerThread.mainHistory[us][slot] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][slot] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 

--- a/src/search.h
+++ b/src/search.h
@@ -118,6 +118,7 @@ struct Stack {
     bool                        followPV;
     int                         cutoffCnt;
     int                         reduction;
+    std::uint16_t               currentFreqSlot;
 };
 
 


### PR DESCRIPTION
## Summary

Variant of mainhist-fa-l128k-c with the do_move LUT load eliminated. Search loop pre-writes ss->currentFreqSlot = mp.lastFreqSlot before each Worker::do_move call (3 sites: probcut, main search, qsearch); do_move no longer recomputes the slot. score<CAPTURES> and score<EVASIONS> now populate freq_slot for ALL moves (not just non-captures), required because promotion-to-queen non-captures route through CAPTURES phase via pos.capture_stage() but their priorCapture-gated mainHistory consumers see priorCapture=false and need a valid slot.

NO_FREQ_SLOT sentinel and its 4 use sites (operator=, lastFreqSlot init, select() miss, do_null_move) wrapped under #if !defined(NDEBUG); release builds skip the writes since the sentinel is purely a debug-mode poison value.

Bench-byte-equal master at depths 13/20/21. Both release and debug builds verified clean.

## Bench

2344696

## Test plan

- [x] Bench byte-equal master, release build
- [x] Bench byte-equal master, debug build (asserts respected, no OOB)
- [ ] Pyshbench 100 runs on watcher (running in background)
- [ ] Fishtest STC SMP if pyshbench shows improvement over mainhist-fa-l128k-stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized move evaluation and history-tracking systems with improved slot-based indexing to enhance chess search performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->