### PR TITLE
Frequency-aware magic index v4: 3-cy pdag, 0x1640 / 0x0FC0 constants (J=0.4280)

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,15 +128,72 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
+inline sf_always_inline constexpr std::uint16_t rol16(std::uint16_t x, unsigned n) {
+    n &= 15u;
+    return static_cast<std::uint16_t>((x << n) | (x >> ((-n) & 15u)));
+}
+
+// Frequency-aware magic index for ButterflyHistory and LowPlyHistory addressing.
+// Clusters frequently-accessed moves into low slot addresses to reduce cache
+// pressure on the hot subset.
+inline sf_always_inline constexpr std::uint16_t magic_index(std::uint16_t raw) {
+    const std::uint16_t a = raw ^ 0x1640u;
+    const std::uint16_t b = rol16(raw, 6) & 0x0FC0u;
+    return a ^ b;
+}
+
+template<typename T, std::size_t Size>
+class alignas(64) MagicIndexedArray: public MultiArray<T, Size> {
+   public:
+    using Base = MultiArray<T, Size>;
+
+    inline sf_always_inline constexpr T& operator[](Move m) noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+    inline sf_always_inline constexpr const T& operator[](Move m) const noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+};
+
+template<typename T, std::size_t Outer, std::size_t Size>
+class MagicIndexedHistory {
+    std::array<MagicIndexedArray<T, Size>, Outer> data_;
+
+   public:
+    constexpr auto& operator[](std::size_t i) noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr const auto& operator[](std::size_t i) const noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr auto begin() noexcept { return data_.begin(); }
+    constexpr auto end() noexcept { return data_.end(); }
+    constexpr auto begin() const noexcept { return data_.begin(); }
+    constexpr auto end() const noexcept { return data_.end(); }
+    template<typename U>
+    void fill(const U& v) {
+        for (auto& row : data_)
+            row.fill(v);
+    }
+};
+
 // ButterflyHistory records how often quiet moves have been successful or unsuccessful
 // during the current search, and is used for reduction and move ordering decisions.
 // It uses 2 tables (one for each color) indexed by the move's from and to squares,
 // see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+using ButterflyHistory =
+  MagicIndexedHistory<StatsEntry<std::int16_t, 7183>, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+using LowPlyHistory =
+  MagicIndexedHistory<StatsEntry<std::int16_t, 7183>, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -228,7 +228,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         else if constexpr (Type == QUIETS)
         {
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][m];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -246,7 +246,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m] / (1 + ply);
         }
 
         else  // Type == EVASIONS
@@ -254,7 +254,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value = (*mainHistory)[us][m] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,8 +318,8 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
-            mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
+        for (auto& slot : mainHistory[c])
+            slot = slot * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (rootDepth + 1 < MAX_PLY && !threads.stop
@@ -897,7 +897,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][(ss - 1)->currentMove] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1127,7 +1127,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][move] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1254,8 +1254,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
-                          + (*contHist[0])[movedPiece][move.to_sq()]
+            ss->statScore = 2 * mainHistory[us][move] + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
         // Decrease/increase reduction for moves with a good/bad history
@@ -1476,7 +1475,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][(ss - 1)->currentMove] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1925,10 +1924,10 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][move] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 2344696

v14 pdag-search Pareto-dominator. Same shape as mainhist-magic-3 (3-cy formula, alignas(64) rows), constants swapped: XOR 0x1234 -> 0x1640, AND 0x0FFF -> 0x0FC0. The new mask 0x0FC0 = bits 6-11 makes the formula a strict permutation of v3's 0x0FFF version with different cycle structure in the F_2-linear map.

Bijective on full uint16: linear part L(raw) = raw ^ (rol16(raw, 6) & 0x0FC0) per bit, L[i] = raw[i] for i in [0,5] or [12,15] and L[i] = raw[i] XOR raw[i-6] for i in [6,11]. Inversion recovers all bits uniquely. Verified by enumeration (scratchpad/verify-pdag-bijection-v4.cpp).

J = 0.4280 on the 1899-active-raw mh+lp dataset (rho_mh = 0.4417, rho_lp = 0.4280). Matches mainhist-magic-2's J at v3's 4-ALU-op cycle count -- strictly Pareto-better than both shipped branches in J x cyc.

Build: WSL Linux gcc 13.3.0, PGO + LTO, ARCH=x86-64-avx512icl, COMP=gcc, EXTRAPROFILEFLAGS=-fprofile-update=atomic.