### PR TITLE
Compact magic-1: 8192-slot mainhist + lowply, structurally bounded

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -40,12 +40,16 @@ constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+constexpr int MAGIC_HISTORY_SIZE       = 8192;  // compact butterfly + lowply slot count
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
 
 static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
               "CORRHIST_BASE_SIZE has to be a power of 2");
+
+static_assert((MAGIC_HISTORY_SIZE & (MAGIC_HISTORY_SIZE - 1)) == 0,
+              "MAGIC_HISTORY_SIZE has to be a power of 2");
 
 // StatsEntry is the container of various numerical statistics. We use a class
 // instead of a naked value to directly call history update operator<<() on
@@ -128,15 +132,85 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
+inline sf_always_inline constexpr std::uint16_t rol16(std::uint16_t x, unsigned n) {
+    n &= 15u;
+    return static_cast<std::uint16_t>((x << n) | (x >> ((-n) & 15u)));
+}
+
+// Compact magic index for ButterflyHistory and LowPlyHistory. Maps raw moves
+// into a 13-bit slot range [0, 8191].
+inline sf_always_inline constexpr std::uint16_t magic_index(std::uint16_t raw) {
+    const std::uint16_t r1 = static_cast<std::uint16_t>(raw & 0xE004u);
+    const std::uint16_t r2 = static_cast<std::uint16_t>(r1 ^ (r1 << 9));
+    const std::uint16_t r3 = static_cast<std::uint16_t>(raw ^ (raw >> 3));
+    return static_cast<std::uint16_t>(r2 ^ r3);
+}
+
+constexpr std::uint32_t magic_index_max_over_uint16() {
+    std::uint32_t m = 0;
+    for (std::uint32_t r = 0; r < 65536u; ++r)
+    {
+        std::uint16_t y = magic_index(static_cast<std::uint16_t>(r));
+        if (y > m)
+            m = y;
+    }
+    return m;
+}
+
+static_assert(magic_index_max_over_uint16() < MAGIC_HISTORY_SIZE);
+
+template<typename T, std::size_t Size>
+class alignas(64) MagicIndexedArray: public MultiArray<T, Size> {
+   public:
+    using Base = MultiArray<T, Size>;
+
+    inline sf_always_inline constexpr T& operator[](Move m) noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+    inline sf_always_inline constexpr const T& operator[](Move m) const noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+};
+
+template<typename T, std::size_t Outer, std::size_t Size>
+class MagicIndexedHistory {
+    std::array<MagicIndexedArray<T, Size>, Outer> data_;
+
+   public:
+    constexpr auto& operator[](std::size_t i) noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr const auto& operator[](std::size_t i) const noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr auto begin() noexcept { return data_.begin(); }
+    constexpr auto end() noexcept { return data_.end(); }
+    constexpr auto begin() const noexcept { return data_.begin(); }
+    constexpr auto end() const noexcept { return data_.end(); }
+    template<typename U>
+    void fill(const U& v) {
+        for (auto& row : data_)
+            row.fill(v);
+    }
+};
+
 // ButterflyHistory records how often quiet moves have been successful or unsuccessful
 // during the current search, and is used for reduction and move ordering decisions.
 // It uses 2 tables (one for each color) indexed by the move's from and to squares,
 // see https://www.chessprogramming.org/Butterfly_Boards
-using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
+using ButterflyHistory =
+  MagicIndexedHistory<StatsEntry<std::int16_t, 7183>, COLOR_NB, MAGIC_HISTORY_SIZE>;
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+using LowPlyHistory =
+  MagicIndexedHistory<StatsEntry<std::int16_t, 7183>, LOW_PLY_HISTORY_SIZE, MAGIC_HISTORY_SIZE>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -228,7 +228,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         else if constexpr (Type == QUIETS)
         {
             // histories
-            m.value = 2 * (*mainHistory)[us][m.raw()];
+            m.value = 2 * (*mainHistory)[us][m];
             m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -246,7 +246,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m] / (1 + ply);
         }
 
         else  // Type == EVASIONS
@@ -254,7 +254,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
+                m.value = (*mainHistory)[us][m] + (*continuationHistory[0])[pc][to];
         }
     }
     return it;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,8 +318,8 @@ bool Search::Worker::iterative_deepening() {
     lowPlyHistory.fill(98);
 
     for (Color c : {WHITE, BLACK})
-        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
-            mainHistory[c][i] = mainHistory[c][i] * 820 / 1024;
+        for (auto& slot : mainHistory[c])
+            slot = slot * 820 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (rootDepth + 1 < MAX_PLY && !threads.stop
@@ -897,7 +897,7 @@ Value Search::Worker::search(
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -214, 171) + 60;
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 10;
+        mainHistory[~us][(ss - 1)->currentMove] << evalDiff * 10;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 12;
@@ -1127,7 +1127,7 @@ moves_loop:  // When in check, search starts here
                 if (history < -4097 * depth)
                     continue;
 
-                history += 71 * mainHistory[us][move.raw()] / 32;
+                history += 71 * mainHistory[us][move] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
@@ -1254,8 +1254,7 @@ moves_loop:  // When in check, search starts here
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128
                           + captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
-            ss->statScore = 2 * mainHistory[us][move.raw()]
-                          + (*contHist[0])[movedPiece][move.to_sq()]
+            ss->statScore = 2 * mainHistory[us][move] + (*contHist[0])[movedPiece][move.to_sq()]
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
         // Decrease/increase reduction for moves with a good/bad history
@@ -1476,7 +1475,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 221 / 16384);
 
-        mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 235 / 32768;
+        mainHistory[~us][(ss - 1)->currentMove] << scaledBonus * 235 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
@@ -1925,10 +1924,10 @@ void update_quiet_histories(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
     Color us = pos.side_to_move();
-    workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
+    workerThread.mainHistory[us][move] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
Bench: 2344696

First branch in the "compaction track". Same magic-index scaffolding as mainhist-magic-5 (alignas(64), constexpr rol16/magic_index, assert on MagicIndexedHistory operator[]) but the table size shrinks from 65536 to 8192 slots per row for both ButterflyHistory and LowPlyHistory (8x footprint reduction; 7 hot rows save ~1.6 MB per worker).

Formula:
const std::uint16_t r1 = static_cast<std::uint16_t>(raw & 0xE004u);
const std::uint16_t r2 = static_cast<std::uint16_t>(r1 ^ (r1 << 9));
const std::uint16_t r3 = static_cast<std::uint16_t>(raw ^ (raw >> 3));
return static_cast<std::uint16_t>(r2 ^ r3);

4 ALU ops, ~5 cy critical path. The high three bits of the output cancel structurally for every uint16 input: r1 = raw & 0xE004 keeps only bits {2, 13, 14, 15}; the shifted-self xor adds nothing to bits 13/14/15 (source bits 4/5/6 of r1 are zero by mask); r2 bits 13/14/15 equal raw's bits 13/14/15; r3 = raw ^ (raw>>3) bits 13/14/15 also equal raw's bits 13/14/15 (raw bits 16+ are zero in uint16); out bits 13/14/15 = raw[i] XOR raw[i] = 0. Verified at compile time:

constexpr std::uint32_t magic_index_max_over_uint16() {
    std::uint32_t m = 0;
    for (std::uint32_t r = 0; r < 65536u; ++r) {
        std::uint16_t y = magic_index(static_cast<std::uint16_t>(r));
        if (y > m) m = y;
    }
    return m;
}
static_assert(magic_index_max_over_uint16() < MAGIC_HISTORY_SIZE);

The constexpr loop enumerates all 65536 inputs at compile time. static_assert proves the formula stays in [0, 8191] without a runtime AND mask.

Bijective on the 1899 active raws (instrumented across STC, LTC, SMP-STC, SMP-LTC, DFRC); inactive raws may collide (Cat 1 trade-off). Bench-byte-equal master because bench raws are a subset of the active set. J = +0.0942 on the active set (master natural is +0.1510), but the primary objective on this branch is table-size compaction; J is a free byproduct.

Build: WSL Linux gcc 13.3.0, PGO + LTO, ARCH=x86-64-avx512icl, COMP=gcc, EXTRAPROFILEFLAGS=-fprofile-update=atomic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized move history table implementation with compact indexing mechanism
  * Updated history indexing and scoring across search and move-selection routines
  * Reduced memory overhead while maintaining existing update behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->