### PR TITLE
Frequency-aware lowply magic index v2 with uint32_t signatures and inlined rol; movzx eliminated

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -128,6 +128,61 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
+inline sf_always_inline constexpr std::uint16_t rol16(std::uint16_t x, unsigned n) {
+    n &= 15u;
+    return static_cast<std::uint16_t>((x << n) | (x >> ((-n) & 15u)));
+}
+
+// Frequency-aware magic index for the LowPlyHistory addressing.
+// Clusters frequently-accessed moves into low slot addresses to reduce cache
+// pressure on the hot subset.
+inline sf_always_inline constexpr std::uint16_t magic_index(std::uint16_t raw) {
+    const std::uint16_t a = raw ^ 0x3672u;
+    const std::uint16_t b = rol16(raw, 6) & 0x0FE3u;
+    return a ^ b;
+}
+
+template<typename T, std::size_t Size>
+class alignas(64) MagicIndexedArray: public MultiArray<T, Size> {
+   public:
+    using Base = MultiArray<T, Size>;
+
+    inline sf_always_inline constexpr T& operator[](Move m) noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+    inline sf_always_inline constexpr const T& operator[](Move m) const noexcept {
+        const std::uint16_t idx = magic_index(m.raw());
+        assert(idx < Size);
+        return Base::operator[](idx);
+    }
+};
+
+template<typename T, std::size_t Outer, std::size_t Size>
+class MagicIndexedHistory {
+    std::array<MagicIndexedArray<T, Size>, Outer> data_;
+
+   public:
+    constexpr auto& operator[](std::size_t i) noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr const auto& operator[](std::size_t i) const noexcept {
+        assert(i < Outer);
+        return data_[i];
+    }
+    constexpr auto begin() noexcept { return data_.begin(); }
+    constexpr auto end() noexcept { return data_.end(); }
+    constexpr auto begin() const noexcept { return data_.begin(); }
+    constexpr auto end() const noexcept { return data_.end(); }
+    template<typename U>
+    void fill(const U& v) {
+        for (auto& row : data_)
+            row.fill(v);
+    }
+};
+
 // ButterflyHistory records how often quiet moves have been successful or unsuccessful
 // during the current search, and is used for reduction and move ordering decisions.
 // It uses 2 tables (one for each color) indexed by the move's from and to squares,
@@ -136,7 +191,8 @@ using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZ
 
 // LowPlyHistory is addressed by ply and move's from and to squares, used
 // to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+using LowPlyHistory =
+  MagicIndexedHistory<StatsEntry<std::int16_t, 7183>, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/history.h
+++ b/src/history.h
@@ -128,18 +128,14 @@ struct DynStats {
     LargePagePtr<T[]> data;
 };
 
-inline sf_always_inline constexpr std::uint16_t rol16(std::uint16_t x, unsigned n) {
-    n &= 15u;
-    return static_cast<std::uint16_t>((x << n) | (x >> ((-n) & 15u)));
-}
-
 // Frequency-aware magic index for the LowPlyHistory addressing.
 // Clusters frequently-accessed moves into low slot addresses to reduce cache
 // pressure on the hot subset.
-inline sf_always_inline constexpr std::uint16_t magic_index(std::uint16_t raw) {
-    const std::uint16_t a = raw ^ 0x3672u;
-    const std::uint16_t b = rol16(raw, 6) & 0x0FE3u;
-    return a ^ b;
+inline sf_always_inline constexpr std::uint32_t magic_index(std::uint32_t raw) {
+    // Receives and returns std::uint32_t to avoid 16-bit-operand codegen that
+    // would force a movzx tail before the value can be used as an array index.
+    const std::uint32_t b = ((raw << 6) | (raw >> 10)) & 0x0FE3u;
+    return (raw ^ b) ^ 0x3672u;
 }
 
 template<typename T, std::size_t Size>
@@ -148,12 +144,12 @@ class alignas(64) MagicIndexedArray: public MultiArray<T, Size> {
     using Base = MultiArray<T, Size>;
 
     inline sf_always_inline constexpr T& operator[](Move m) noexcept {
-        const std::uint16_t idx = magic_index(m.raw());
+        const std::uint32_t idx = magic_index(m.raw());
         assert(idx < Size);
         return Base::operator[](idx);
     }
     inline sf_always_inline constexpr const T& operator[](Move m) const noexcept {
-        const std::uint16_t idx = magic_index(m.raw());
+        const std::uint32_t idx = magic_index(m.raw());
         assert(idx < Size);
         return Base::operator[](idx);
     }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -246,7 +246,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m] / (1 + ply);
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1928,7 +1928,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 682 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move] << bonus * 682 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 894 / 1024);
 


### PR DESCRIPTION
v2 of lowply-magic-4. magic_index signature changed to uint32_t. rol16 inlined as ((raw<<6) | (raw>>10)) using 32-bit shifts; AND with 0x0FE3 absorbs high-bit garbage. Formula reordered as (raw ^ b) ^ K to keep gcc in 32-bit chain. 0 movzx in inlined sites (vs N in original). Bench: 2344696.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal move history indexing implementation to improve performance and memory efficiency in move evaluation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximmasiutin/Stockfish/pull/385)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->