### PR TITLE
LowPlyHistory: skip ply 3, SPSA-tuned weights for {0,1,2,4}

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -39,7 +39,49 @@ constexpr int PAWN_HISTORY_BASE_SIZE   = 8192;  // has to be a power of 2
 constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
 constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
-constexpr int LOW_PLY_HISTORY_SIZE     = 5;
+
+// LowPlyHistory has rows only for plies in {0, 1, 2, 4}; ply 3 has no row.
+// Define the topology by exclusion: plies in [0, LOW_PLY_HISTORY_MAX_PLY)
+// have rows, except for LOW_PLY_HISTORY_SKIP_PLY.
+constexpr int LOW_PLY_HISTORY_MAX_PLY  = 5;
+constexpr int LOW_PLY_HISTORY_SKIP_PLY = 3;
+
+constexpr bool has_low_ply_history(int ply) {
+    return std::size_t(ply) < LOW_PLY_HISTORY_MAX_PLY && ply != LOW_PLY_HISTORY_SKIP_PLY;
+}
+
+// Count plies in [0, LOW_PLY_HISTORY_MAX_PLY) that have a row; this is the
+// number of rows the LowPlyHistory array must hold.
+constexpr std::size_t compute_low_ply_history_size() {
+    std::size_t count = 0;
+    for (int p = 0; p < LOW_PLY_HISTORY_MAX_PLY; ++p)
+        if (has_low_ply_history(p))
+            ++count;
+    return count;
+}
+
+constexpr std::size_t LOW_PLY_HISTORY_SIZE = compute_low_ply_history_size();
+
+// Translate a ply (precondition: has_low_ply_history(ply)) to its row index
+// in [0, LOW_PLY_HISTORY_SIZE).  Written as ply - (ply > SKIP_PLY) so the
+// compiler CSEs the cmp with the gate's != SKIP_PLY check.
+constexpr int low_ply_history_index(int ply) { return ply - (ply > LOW_PLY_HISTORY_SKIP_PLY); }
+
+constexpr bool low_ply_history_index_is_bijection() {
+    std::size_t expected = 0;
+    for (int p = 0; p < LOW_PLY_HISTORY_MAX_PLY; ++p)
+        if (has_low_ply_history(p))
+        {
+            if (std::size_t(low_ply_history_index(p)) != expected)
+                return false;
+            ++expected;
+        }
+    return expected == LOW_PLY_HISTORY_SIZE;
+}
+
+static_assert(low_ply_history_index_is_bijection(),
+              "low_ply_history_index must map valid plies to contiguous [0, LOW_PLY_HISTORY_SIZE); "
+              "if you changed the topology, update low_ply_history_index accordingly");
 
 static_assert((PAWN_HISTORY_BASE_SIZE & (PAWN_HISTORY_BASE_SIZE - 1)) == 0,
               "PAWN_HISTORY_BASE_SIZE has to be a power of 2");
@@ -134,9 +176,13 @@ struct DynStats {
 // see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, UINT_16_HISTORY_SIZE>;
 
-// LowPlyHistory is addressed by ply and move's from and to squares, used
-// to improve move ordering near the root
-using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
+// LowPlyHistory is addressed by a row index (NOT directly by ply) and the
+// move's packed from/to bits, used to improve move ordering near the root.
+// Translate a ply to its row via low_ply_history_index() and gate access
+// with has_low_ply_history().  LowPlyHistoryRow is the row type returned
+// by indexing LowPlyHistory with a single row index.
+using LowPlyHistoryRow = Stats<std::int16_t, 7183, UINT_16_HISTORY_SIZE>;
+using LowPlyHistory    = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZE>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -18,7 +18,9 @@
 
 #include "movepick.h"
 
+#include <array>
 #include <cassert>
+#include <cstdint>
 #include <limits>
 #include <utility>
 
@@ -198,7 +200,9 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
     Color us = pos.side_to_move();
 
-    [[maybe_unused]] Bitboard threatByLesser[KING + 1];
+    [[maybe_unused]] Bitboard                threatByLesser[KING + 1];
+    [[maybe_unused]] int                     lowPlyWeight = 0;
+    [[maybe_unused]] const LowPlyHistoryRow* lowPlyRow    = nullptr;
     if constexpr (Type == QUIETS)
     {
         threatByLesser[PAWN]   = 0;
@@ -207,6 +211,15 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
         threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
         threatByLesser[KING]  = 0;
+
+        if (has_low_ply_history(ply))
+        {
+            static constexpr std::array<std::int16_t, LOW_PLY_HISTORY_SIZE> lowPlyWeights = {
+              8278, 4603, 5505, 7204};
+            const std::size_t lowPlyIdx = std::size_t(low_ply_history_index(ply));
+            lowPlyWeight                = lowPlyWeights[lowPlyIdx];
+            lowPlyRow                   = &(*lowPlyHistory)[lowPlyIdx];
+        }
     }
 
     ExtMove* it = cur;
@@ -245,8 +258,8 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             m.value += PieceValue[pt] * v;
 
 
-            if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.raw()] / (1 + ply);
+            if (lowPlyRow)
+                m.value += lowPlyWeight * (*lowPlyRow)[m.raw()] >> 10;
         }
 
         else  // Type == EVASIONS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1929,8 +1929,9 @@ void update_quiet_histories(
     Color us = pos.side_to_move();
     workerThread.mainHistory[us][move.raw()] << bonus;  // Untuned to prevent duplicate effort
 
-    if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.raw()] << bonus * 663 / 1024;
+    if (has_low_ply_history(ss->ply))
+        workerThread.lowPlyHistory[low_ply_history_index(ss->ply)][move.raw()]
+          << bonus * 663 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 820 / 1024);
 


### PR DESCRIPTION
## Summary

- Drops the LowPlyHistory row for ply 3 (SPSA tune drove its weight to zero) and shrinks the array from 5 to 4 rows.
- Retunes the four remaining weights {0, 1, 2, 4} to SPSA-derived values {8223, 4857, 5450, 7060}.
- Array size, gate, and ply-to-row mapping live in history.h and are validated by a static_assert bijection check so future topology changes either keep working or fail at compile time.
- Hot-path read site (movepick.cpp QUIETS) and write site (search.cpp update_quiet_histories) go through has_low_ply_history() / low_ply_history_index().
- Codegen verified: gate emits two predictable cmp/branch pairs; the cmp against SKIP_PLY is CSE-shared with the index function setg on the read-site hoist, producing the predicted minimal lowering. See diffs/lowply-wt5-w3-skip3.md for the annotated asm.

Bench: 2599843

## Test plan

- [ ] Local PGO build clean (mingw GCC 15, x86-64-avx512icl, atomic profile flag): bench reproduces 2599843
- [ ] Fishtest STC 1T against current master
- [ ] If STC passes: Fishtest LTC 1T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored move history tracking system with improved compile-time configurability and optimized indexing logic for enhanced efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximmasiutin/Stockfish/pull/389)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->