### PR TITLE
Dampen shallow LMR fail-low loser malus to 0.85x

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -144,7 +144,8 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            ttMove);
+                      Move            ttMove,
+                      uint32_t        quietsShallowMask);
 
 bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
     if (pos.capture_stage(move) || pos.rule50_count() < 10)
@@ -1040,8 +1041,10 @@ moves_loop:  // When in check, search starts here
 
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
+    uint32_t quietsShallowMask = 0;
     while ((move = mp.next_move()) != Move::none())
     {
+        bool lmrFailLowOnly = false;
         assert(move.is_ok());
 
         if (move == excludedMove)
@@ -1281,6 +1284,8 @@ moves_loop:  // When in check, search starts here
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
 
+            lmrFailLowOnly = (value <= alpha) && (d < newDepth);
+
             // Do a full-depth search when reduced LMR search fails high
             // (*Scaler) Shallower searches here don't scale well
             if (value > alpha)
@@ -1432,7 +1437,10 @@ moves_loop:  // When in check, search starts here
             if (capture)
                 capturesSearched.push_back(move);
             else
+            {
+                quietsShallowMask |= uint32_t(lmrFailLowOnly) << quietsSearched.size();
                 quietsSearched.push_back(move);
+            }
         }
     }
 
@@ -1455,7 +1463,7 @@ moves_loop:  // When in check, search starts here
     else if (bestMove)
     {
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
-                         ttData.move);
+                         ttData.move, quietsShallowMask);
         if (!PvNode)
             ttMoveHistory << (bestMove == ttData.move ? 792 : -779);
     }
@@ -1849,7 +1857,8 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            ttMove) {
+                      Move            ttMove,
+                      uint32_t        quietsShallowMask) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  movedPiece     = pos.moved_piece(bestMove);
@@ -1863,12 +1872,15 @@ void update_all_stats(const Position& pos,
     {
         update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 824 / 1024);
 
-        int actualMalus = malus * 1136 / 1024;
+        unsigned actualMalus = unsigned(malus) * 1136 / 1024;
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
         {
+            bool shallow = quietsShallowMask & 1u;
+            quietsShallowMask >>= 1;
             actualMalus = actualMalus * 956 / 1024;
-            update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
+            update_quiet_histories(pos, ss, workerThread, move,
+                                   -int(actualMalus * (1024 - 154 * shallow) / 1024));
         }
     }
     else


### PR DESCRIPTION
Quiet moves that failed low only at a shallow LMR-reduced depth
(d < newDepth) receive 85% of the normal history penalty instead of
100%.  A uint32_t bitmask tracks which quiet losers were shallow,
consumed bit-by-bit with & 1u / >>= 1.

actualMalus is unsigned so all /1024 compile to shr 10 (no signed
fixup).  GCC fuses the 1024 - 154*shallow computation into
neg + and 0x66 + add 0x400 (branchless, no multiply).

Bench: 2488703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal search algorithm statistics tracking for improved move evaluation efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximmasiutin/Stockfish/pull/391)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->